### PR TITLE
Nsjail Clone Fix

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update  \
         linux-headers~=4.19 \
         make~=4.2 \
         protobuf-dev~=3.6
-RUN git clone --depth=1 https://github.com/google/nsjail.git /nsjail \
+RUN git clone https://github.com/google/nsjail.git /nsjail \
     && cd /nsjail \
     && git checkout 0b1d5ac03932c140f08536ed72b4b58741e7d3cf
 WORKDIR /nsjail


### PR DESCRIPTION
Unspecify the depth to make the clone non-shallow again. A depth of 1 was too shallow as it only allowed the latest commit to be cloned. An arbitrary larger depth would still break eventually. The repository is small enough to not warrant a shallow clone anyway.