### PR TITLE
Use pipenv sync instead of pipenv --sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [`snekapi.py`](snekbox/api/snekapi.py) and [`resources`](snekbox/api/resourc
 A Python 3.7 interpreter and the [pipenv](https://docs.pipenv.org/en/latest/) package are required. Once those requirements are satisfied, install the project's dependencies:
 
 ```
-pipenv --sync
+pipenv sync
 ```
 
 Follow that up with setting up the pre-commit hook:


### PR DESCRIPTION
The pipenv docs page certificate seems to be having issues at the moment, but `pipenv --sync` doesn't work for me (Ubuntu 18.04, pipenv version 2018.11.26, Python3.7.4, Gnome Terminal), as described in the README; what works for me, and what I generally see used instead, is `pipenv sync`. Could we change the README to reflect this?

Thanks! ^_^