### PR TITLE
CI: fix incorrect CWD for check script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
         name: check
         inputs:
           scriptPath: scripts/check_dockerfiles.sh
+          disableAutoCwd: true
 
       # Without a login the following Docker build tasks won't add image tags.
       - task: Docker@1

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -21,6 +21,7 @@ RUN make
 
 FROM python:3.8.0-slim-buster
 ENV PIP_NO_CACHE_DIR=false
+
 RUN apt-get -y update \
     && apt-get install -y \
         gcc=4:8.3.* \
@@ -28,5 +29,6 @@ RUN apt-get -y update \
         libprotobuf17=3.6.* \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install pipenv==2018.11.26
+
 COPY --from=builder /nsjail/nsjail /usr/sbin/
 RUN chmod +x /usr/sbin/nsjail


### PR DESCRIPTION
The CWD was being set to the scripts folder so `git diff` could not locate the Dockerfiles or Pipfiles.