### PR TITLE
Configure a proper chroot jail for NsJail

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,8 @@
 *
 
 # Make exceptions for what's needed
-!docker/.profile
 !snekbox
+!snekbox.cfg
 !tests
 !Pipfile
 !Pipfile.lock

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ result <- |             |<----------|           | <----------+
 
 The code is executed in a Python process that is launched through [NsJail](https://github.com/google/nsjail), which is responsible for sandboxing the Python process. NsJail is configured as follows:
 
-* Root directory is mounted as read-only
+* All mounts are read-only
 * Time limit of 2 seconds
 * Maximum of 1 PID
 * Maximum memory of 52428800 bytes

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ result <- |             |<----------|           | <----------+
 The code is executed in a Python process that is launched through [NsJail](https://github.com/google/nsjail), which is responsible for sandboxing the Python process. NsJail is configured as follows:
 
 * All mounts are read-only
-* Time limit of 2 seconds
+* Time limit of 5 seconds
 * Maximum of 1 PID
 * Maximum memory of 52428800 bytes
 * Loopback interface is down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: pythondiscord/snekbox:latest
     network_mode: "host"
     init: true
+    ipc: none
     build:
       context: .
       dockerfile: docker/Dockerfile

--- a/docker/venv.Dockerfile
+++ b/docker/venv.Dockerfile
@@ -7,7 +7,7 @@ ENV PIP_NO_CACHE_DIR=false \
     PIPENV_NOSPIN=1 \
     PIPENV_VENV_IN_PROJECT=1
 
-COPY Pipfile Pipfile.lock /snekbox/
+COPY Pipfile Pipfile.lock snekbox.cfg /snekbox/
 WORKDIR /snekbox
 
 RUN if [ -n "${DEV}" ]; then pipenv sync --dev; else pipenv sync; fi

--- a/scripts/.profile
+++ b/scripts/.profile
@@ -17,5 +17,5 @@ nsjpy() {
     nsjail \
         --config "${NSJAIL_CFG:-/snekbox/snekbox.cfg}" \
         $nsj_args -- \
-        /snekbox/.venv/bin/python3 -Iq -c "$@"
+        /snekbox/.venv/bin/python3 -Iqu -c "$@"
 }

--- a/scripts/.profile
+++ b/scripts/.profile
@@ -15,23 +15,7 @@ nsjpy() {
     echo "${MEM_MAX}" > /sys/fs/cgroup/memory/NSJAIL/memory.memsw.limit_in_bytes
 
     nsjail \
-        -Mo \
-        --rlimit_as 700 \
-        --chroot / \
-        -E LANG=en_US.UTF-8 \
-        -E OMP_NUM_THREADS=1 \
-        -E OPENBLAS_NUM_THREADS=1 \
-        -E MKL_NUM_THREADS=1 \
-        -E VECLIB_MAXIMUM_THREADS=1 \
-        -E NUMEXPR_NUM_THREADS=1 \
-        -R/usr -R/lib -R/lib64 \
-        --user 65534 \
-        --group 65534 \
-        --time_limit 2 \
-        --disable_proc \
-        --iface_no_lo \
-        --cgroup_pids_max=1 \
-        --cgroup_mem_max="${MEM_MAX}" \
+        --config "${NSJAIL_CFG:-/snekbox/snekbox.cfg}" \
         $nsj_args -- \
         /snekbox/.venv/bin/python3 -Iq -c "$@"
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -40,6 +40,7 @@ docker run \
     --privileged \
     --network host \
     --hostname pdsnk-dev \
+    --ipc="none" \
     -e PYTHONDONTWRITEBYTECODE=1 \
     -e PIPENV_PIPFILE="/snekbox/Pipfile" \
     -e BASH_ENV="${PWD}/scripts/.profile" \

--- a/snekbox.cfg
+++ b/snekbox.cfg
@@ -93,5 +93,5 @@ iface_no_lo: true
 
 exec_bin {
     path: "/snekbox/.venv/bin/python3"
-    arg: "-Iq"
+    arg: "-Iqu"
 }

--- a/snekbox.cfg
+++ b/snekbox.cfg
@@ -68,6 +68,13 @@ mount {
 }
 
 mount {
+    src: "/usr/lib"
+    dst: "/usr/lib"
+    is_bind: true
+    rw: false
+}
+
+mount {
     src: "/usr/local/lib"
     dst: "/usr/local/lib"
     is_bind: true

--- a/snekbox.cfg
+++ b/snekbox.cfg
@@ -5,7 +5,7 @@ mode: ONCE
 hostname: "snekbox"
 cwd: "/snekbox"
 
-time_limit: 2
+time_limit: 5
 
 keep_env: false
 envar: "LANG=en_US.UTF-8"

--- a/snekbox.cfg
+++ b/snekbox.cfg
@@ -1,0 +1,90 @@
+name: "snekbox"
+description: "Execute Python"
+
+mode: ONCE
+hostname: "snekbox"
+cwd: "/snekbox"
+
+time_limit: 2
+
+keep_env: false
+envar: "LANG=en_US.UTF-8"
+envar: "OMP_NUM_THREADS=1"
+envar: "OPENBLAS_NUM_THREADS=1"
+envar: "MKL_NUM_THREADS=1"
+envar: "VECLIB_MAXIMUM_THREADS=1"
+envar: "NUMEXPR_NUM_THREADS=1"
+
+keep_caps: false
+
+rlimit_as: 700
+
+clone_newnet: true
+clone_newuser: true
+clone_newns: true
+clone_newpid: true
+clone_newipc: true
+clone_newuts: true
+clone_newcgroup: true
+
+uidmap {
+    inside_id: "65534"
+    outside_id: "65534"
+}
+
+gidmap {
+    inside_id: "65534"
+    outside_id: "65534"
+}
+
+mount_proc: false
+
+mount {
+    src: "/etc/ld.so.cache"
+    dst: "/etc/ld.so.cache"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/lib"
+    dst: "/lib"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/lib64"
+    dst: "/lib64"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/snekbox"
+    dst: "/snekbox"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/usr/local/lib"
+    dst: "/usr/local/lib"
+    is_bind: true
+    rw: false
+}
+
+cgroup_mem_max: 52428800
+cgroup_mem_mount: "/sys/fs/cgroup/memory"
+cgroup_mem_parent: "NSJAIL"
+
+cgroup_pids_max: 1
+cgroup_pids_mount: "/sys/fs/cgroup/pids"
+cgroup_pids_parent: "NSJAIL"
+
+iface_no_lo: true
+
+exec_bin {
+    path: "/snekbox/.venv/bin/python3"
+    arg: "-Iq"
+}

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -128,7 +128,7 @@ class NsJail:
                 "--cgroup_pids_mount", str(CGROUP_PIDS_PARENT.parent),
                 "--cgroup_pids_parent", CGROUP_PIDS_PARENT.name,
                 "--",
-                self.python_binary, "-Iq", "-c", code
+                self.python_binary, "-Iqu", "-c", code
             )
 
             msg = "Executing code..."

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -35,7 +35,7 @@ class NsJail:
     Default NsJail configuration (snekbox.cfg):
 
     - All mounts are read-only
-    - Time limit of 2 seconds
+    - Time limit of 5 seconds
     - Maximum of 1 PID
     - Maximum memory of 52428800 bytes
     - Loopback interface is down

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -24,6 +24,7 @@ CGROUP_PIDS_PARENT = Path("/sys/fs/cgroup/pids/NSJAIL")
 CGROUP_MEMORY_PARENT = Path("/sys/fs/cgroup/memory/NSJAIL")
 
 NSJAIL_PATH = os.getenv("NSJAIL_PATH", "/usr/sbin/nsjail")
+NSJAIL_CFG = os.getenv("NSJAIL_CFG", "./snekbox.cfg")
 MEM_MAX = 52428800
 
 
@@ -31,9 +32,9 @@ class NsJail:
     """
     Core Snekbox functionality, providing safe execution of Python code.
 
-    NsJail configuration:
+    Default NsJail configuration (snekbox.cfg):
 
-    - Root directory is mounted as read-only
+    - All mounts are read-only
     - Time limit of 2 seconds
     - Maximum of 1 PID
     - Maximum memory of 52428800 bytes
@@ -117,21 +118,8 @@ class NsJail:
         """Execute Python 3 code in an isolated environment and return the completed process."""
         with NamedTemporaryFile() as nsj_log:
             args = (
-                self.nsjail_binary, "-Mo",
-                "--rlimit_as", "700",
-                "--chroot", "/",
-                "-E", "LANG=en_US.UTF-8",
-                "-E", "OMP_NUM_THREADS=1",
-                "-E", "OPENBLAS_NUM_THREADS=1",
-                "-E", "MKL_NUM_THREADS=1",
-                "-E", "VECLIB_MAXIMUM_THREADS=1",
-                "-E", "NUMEXPR_NUM_THREADS=1",
-                "-R/usr", "-R/lib", "-R/lib64",
-                "--user", "65534",  # nobody
-                "--group", "65534",  # nobody/nogroup
-                "--time_limit", "2",
-                "--disable_proc",
-                "--iface_no_lo",
+                self.nsjail_binary,
+                "--config", NSJAIL_CFG,
                 "--log", nsj_log.name,
                 f"--cgroup_mem_max={MEM_MAX}",
                 "--cgroup_mem_mount", str(CGROUP_MEMORY_PARENT.parent),

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -158,3 +158,19 @@ class NsJailTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, "")
         self.assertEqual(result.stderr, None)
+
+    def test_output_order(self):
+        stdout_msg = "greetings from stdout!"
+        stderr_msg = "hello from stderr!"
+        code = dedent(f"""
+            print({stdout_msg!r})
+            raise ValueError({stderr_msg!r})
+        """).strip()
+
+        result = self.nsjail.python3(code)
+        self.assertLess(
+            result.stdout.find(stdout_msg),
+            result.stdout.find(stderr_msg),
+            msg="stdout does not come before stderr"
+        )
+        self.assertEqual(result.stderr, None)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -122,3 +122,30 @@ class NsJailTests(unittest.TestCase):
             "INFO:snekbox.nsjail:pid=20 ([STANDALONE MODE]) exited with status: 2, (PIDs left: 0)",
             log.output
         )
+
+    def test_shm_and_tmp_not_mounted(self):
+        for path in ("/dev/shm", "/run/shm", "/tmp"):
+            with self.subTest(path=path):
+                code = dedent(f"""
+                    with open('{path}/test', 'wb') as file:
+                        file.write(bytes([255]))
+                """).strip()
+
+                result = self.nsjail.python3(code)
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("No such file or directory", result.stdout)
+                self.assertEqual(result.stderr, None)
+
+    def test_multiprocessing_shared_memory_disabled(self):
+        code = dedent("""
+            from multiprocessing.shared_memory import SharedMemory
+            try:
+                SharedMemory('test', create=True, size=16)
+            except FileExistsError:
+                pass
+        """).strip()
+
+        result = self.nsjail.python3(code)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Function not implemented", result.stdout)
+        self.assertEqual(result.stderr, None)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -152,3 +152,9 @@ class NsJailTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("Function not implemented", result.stdout)
         self.assertEqual(result.stderr, None)
+
+    def test_numpy_import(self):
+        result = self.nsjail.python3("import numpy")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, None)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -56,14 +56,17 @@ class NsJailTests(unittest.TestCase):
         self.assertEqual(result.stderr, None)
 
     def test_read_only_file_system(self):
-        code = dedent("""
-            open('hello', 'w').write('world')
-        """).strip()
+        for path in ("/", "/etc", "/lib", "/lib64", "/snekbox", "/usr"):
+            with self.subTest(path=path):
+                code = dedent(f"""
+                    with open('{path}/hello', 'w') as f:
+                        f.write('world')
+                """).strip()
 
-        result = self.nsjail.python3(code)
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("Read-only file system", result.stdout)
-        self.assertEqual(result.stderr, None)
+                result = self.nsjail.python3(code)
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("Read-only file system", result.stdout)
+                self.assertEqual(result.stderr, None)
 
     def test_forkbomb_resource_unavailable(self):
         code = dedent("""


### PR DESCRIPTION
## Description

devfs and sysfs were problematic since they were being mounted as tmpfs, which is r/w. For example, the Python process could write to cgroups. Now, only what is needed to run Python gets mounted. This boils down to the venv itself and some shared libraries Python needs.

* Use a config file for NsJail instead of command-line options
* Map `65534` (nobody) user & group inside the user namespace to `65534` outside the namespace rather than mapping to current uid/guid (which was `0` AKA root)

## Additional Discussion

#### Unprivileged Docker container

I've explored running the container as unprivileged, which would make Docker mount neither devfs nor sysfs. However, so far this has been problematic mainly because the NsJail cgroup needs to be created. That requires  `/sys` to be mounted and privileges to write to it. There are some experimental Docker features which allow for privileges while building, but I couldn't manage to create the cgroup during the build. In retrospect, it's probably because `/sys` wasn't mounted anyway (would need to double check if it gets mounted during build).

Regardless, it is questionable what advantages running as unprivileged would have when NsJail is already being employed and now a (hopefully) proper chroot jail is configured. Of course, giving privileges when they aren't needed is always something one would rather not do. Doing away with privileges in this case just doesn't seem trivial to accomplish.

#### Ownership inside NsJail

Inside NsJail, `ls` shows all mounted files and directories are owned by `65534`. Though theoretically everything is mounted as read-only, this is still a bit concerning since the owner has write permissions. 

However, the output of `ls` may be a bit misleading: according to one of the maintainers of NsJail, it is overflowing to `65534` because the root uid/guid is not mapped in the user namespace. If root is mapped to e.g. `12345` inside, then all files show as belonging to `12345` instead, which seems to be correct because everything in the Docker container is owned by root (`USER` is never specified in the Dockerfiles so I guess Docker defaults to using root when copying from the host).