### PR TITLE
Use port mapping, change container name to snekbox.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: "3.7"
 services:
-  pdsnk:
-    hostname: "pdsnk"
+  snekbox:
+    container_name: snekbox
     privileged: true
     image: pythondiscord/snekbox:latest
-    network_mode: "host"
+    ports:
+     - 8060:8060
     init: true
     ipc: none
     build:


### PR DESCRIPTION
Closes #58 

The provided compose currently runs in host mode, which is unnecessary. This adjusts it back to only expose the required port.

The service name has been changed to "snekbox" instead also, as we're moving away from using the `pd` prefix on our services. It also doesn't make too much sense to have such a prefix and shortened name if we're to accommodate public usage.

The hostname field has been removed, and container_name field added. By default, the hostname will be set to the same as the container name unless otherwise specified. To ensure the container name and hostname is predictably the same as the service name, container_name been explicitly specified.