### PR TITLE
Add pep8-naming and more pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,15 @@
 [flake8]
-max-line-length=100
-application_import_names=snekbox
-docstring-convention=all
-ignore=
-    P102,B311,W503,E226,S311,
+allow-untyped-nested = true
+application_import_names = snekbox
+docstring-convention = all
+import-order-style = pycharm
+inline-quotes = "
+max-line-length = 100
+
+exclude = __pycache__,.cache,user_base,venv,.venv
+
+ignore =
+    W503,
     # Missing Docstrings
     D100,D104,D105,D107,
     # Docstring Whitespace
@@ -14,9 +20,5 @@ ignore=
     D400,D401,D402,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D416,D417,
     # Type Annotations
     ANN002,ANN003,ANN101,ANN102,ANN204,ANN206
-exclude=
-    __pycache__,.cache,
-    venv,.venv,user_base
-per-file-ignores=tests/*:D1,ANN
-import-order-style=pycharm
-inline-quotes="
+
+per-file-ignores = tests/*:D1,ANN

--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -102,6 +102,12 @@ jobs:
           docker exec snekbox_test /bin/bash -c
           'pipenv install --system --deploy --dev && pip install numpy'
 
+      # Required by pre-commit.
+      - name: Install git
+        run: >-
+          docker exec snekbox_test /bin/bash -c
+          'apt-get -y update && apt-get install -y git=1:2.20.*'
+
       # Skip the flake8 hook because the following step will run it.
       - name: Run pre-commit hooks
         run: >-

--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -102,6 +102,12 @@ jobs:
           docker exec snekbox_test /bin/bash -c
           'pipenv install --system --deploy --dev && pip install numpy'
 
+      # Skip the flake8 hook because the following step will run it.
+      - name: Run pre-commit hooks
+        run: >-
+          docker exec snekbox_test /bin/bash -c
+          'SKIP=flake8 pre-commit run --all-files'
+
       # This runs `flake8` in the container and asks `flake8` to output
       # linting errors in the format of the command for registering workflow
       # error messages/annotations. This means that Github Actions will pick

--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -98,8 +98,9 @@ jobs:
 
       # One of the unit tests needs to import numpy.
       - name: Install dependencies
-        run: "docker exec snekbox_test /bin/bash -c \
-          'pipenv install --system --deploy --dev && pip install numpy'"
+        run: >-
+          docker exec snekbox_test /bin/bash -c
+          'pipenv install --system --deploy --dev && pip install numpy'
 
       # This runs `flake8` in the container and asks `flake8` to output
       # linting errors in the format of the command for registering workflow
@@ -107,9 +108,10 @@ jobs:
       # up on this output to generate nice annotations to indicate what went
       # wrong where.
       - name: Run linter
-        run: "docker exec snekbox_test /bin/bash -c 'flake8 \
-          --format \"::error file=%(path)s,line=%(row)d,col=%(col)d::\
-          [flake8] %(code)s: %(text)s\"'"
+        run: >-
+          docker exec snekbox_test /bin/bash -c
+          'flake8 --format
+          "::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s"'
 
       # Memory limit tests would fail if this isn't disabled.
       - name: Disable swap memory

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,19 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.6.0
+    hooks:
+      - id: python-check-blanket-noqa
   - repo: local
     hooks:
       - id: flake8

--- a/Pipfile
+++ b/Pipfile
@@ -12,16 +12,16 @@ sentry-sdk = {extras = ["falcon"], version = "~= 0.19.3"}
 [dev-packages]
 coverage = "~= 5.3"
 flake8 = "~= 3.8.4"
-flake8-annotations = "~= 2.4.1"
-flake8-bugbear = "~= 20.1"
+flake8-annotations = "~= 2.5.0"
+flake8-bugbear = "~= 20.11"
 flake8-docstrings = "~= 1.5"
 flake8-formatter-junit-xml = "~= 0.0.6"
 flake8-import-order = "~= 0.18.1"
 flake8-quotes = "~= 3.2"
 flake8-string-format = "~= 0.3.0"
-flake8-tidy-imports = "~= 4.1"
+flake8-tidy-imports = "~= 4.2"
 flake8-todo = "~= 0.7"
-pre-commit = "~= 2.8.2"
+pre-commit = "~= 2.9.3"
 pydocstyle = "~= 5.1"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,7 @@ pydocstyle = "~= 5.1"
 python_version = "3.9"
 
 [scripts]
-lint = "flake8"
+lint = "pre-commit run --all-files"
 precommit = "pre-commit install"
 test = "sh scripts/dev.sh -c 'pipenv run coverage run -m unittest'"
 testb = """

--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ flake8-quotes = "~= 3.2"
 flake8-string-format = "~= 0.3.0"
 flake8-tidy-imports = "~= 4.2"
 flake8-todo = "~= 0.7"
+pep8-naming = "~= 0.11.1"
 pre-commit = "~= 2.9.3"
 pydocstyle = "~= 5.1"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c227f05edf75934ae0c592f2b15186e589905c3439a339eacb2df4ffe4c8b466"
+            "sha256": "b52f6a21f38f4c4e3afa28cfbcd0b63d8f6bcfc44d26bda4e0c1fb3b43eeada3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -205,11 +205,11 @@
         },
         "flake8-annotations": {
             "hashes": [
-                "sha256:0bcebb0792f1f96d617ded674dca7bf64181870bfe5dace353a1483551f8e5f1",
-                "sha256:bebd11a850f6987a943ce8cdff4159767e0f5f89b3c88aca64680c2175ee02df"
+                "sha256:3a377140556aecf11fa9f3bb18c10db01f5ea56dc79a730e2ec9b4f1f49e2055",
+                "sha256:e17947a48a5b9f632fe0c72682fc797c385e451048e7dfb20139f448a074cb3e"
             ],
             "index": "pypi",
-            "version": "==2.4.1"
+            "version": "==2.5.0"
         },
         "flake8-bugbear": {
             "hashes": [
@@ -303,11 +303,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:22e6aa3bd571debb01eb7d34483f11c01b65237be4eebbf30c3d4fb65762d315",
-                "sha256:905ebc9b534b991baec87e934431f2d0606ba27f2b90f7f652985f5a5b8b6ae6"
+                "sha256:6c86d977d00ddc8a60d68eec19f51ef212d9462937acf3ea37c7adec32284ac0",
+                "sha256:ee784c11953e6d8badb97d19bc46b997a3a9eded849881ec587accd8608d74a4"
             ],
             "index": "pypi",
-            "version": "==2.8.2"
+            "version": "==2.9.3"
         },
         "pycodestyle": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b52f6a21f38f4c4e3afa28cfbcd0b63d8f6bcfc44d26bda4e0c1fb3b43eeada3"
+            "sha256": "66cab1b13fdedd58af57fc9c94157d1a686feaedf1b4586274cc4903ba0cca30"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -243,6 +243,13 @@
             "index": "pypi",
             "version": "==0.18.1"
         },
+        "flake8-polyfill": {
+            "hashes": [
+                "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
+                "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
+            ],
+            "version": "==1.0.2"
+        },
         "flake8-quotes": {
             "hashes": [
                 "sha256:3f1116e985ef437c130431ac92f9b3155f8f652fda7405ac22ffdfd7a9d1055e"
@@ -300,6 +307,14 @@
                 "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"
             ],
             "version": "==1.5.0"
+        },
+        "pep8-naming": {
+            "hashes": [
+                "sha256:a1dd47dd243adfe8a83616e27cf03164960b507530f155db94e10b36a6cd6724",
+                "sha256:f43bfe3eea7e0d73e8b5d07d6407ab47f2476ccaeff6937c84275cd30b016738"
+            ],
+            "index": "pypi",
+            "version": "==0.11.1"
         },
         "pre-commit": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ not exposed.
 To expose third-party Python packages during evaluation, install them to the user site:
 
 ```sh
-docker exec snekbox /bin/sh -c 'pip install --ignore-installed --user numpy' 
+docker exec snekbox /bin/sh -c 'pip install --ignore-installed --user numpy'
 ```
 
 In the above command, `snekbox` is the name of the running container. The name may be different and can be checked with `docker ps`.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -24,6 +24,7 @@ if [ "$1" = "--build" ]; then
         if [ -n "${dangling_imgs}" ]; then
             printf "Removing dangling images..."
 
+            # shellcheck disable=SC2086
             docker rmi $dangling_imgs >/dev/null \
             && printf " done!\n" || exit "$?"
         fi


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Resolves #63
python-discord/organisation#138

## Description
<!-- Describe how you've implemented your changes. -->
New hooks were added for pre-commit and they will run in CI too. The `pipenv run lint` script will now run all the new hooks, including flake8.

### Hooks added

A couple of these hooks automatically apply fixes. However, they still report failure and leave any changes they make uncommitted. Therefore, the user has to commit the automatic fixes.

* `check-merge-conflict` - Check for files that contain merge conflict strings.
* `check-toml` - Attempts to load all toml files to verify syntax. 
* `check-yaml` - Attempts to load all yaml files to verify syntax. 
* `end-of-file-fixer` - Makes sure files end in a newline and only a newline.
* `mixed-line-ending` - Replaces mixed line endings with LF. 
* `trailing-whitespace` - Trims trailing whitespace.
* `python-check-blanket-noqa` - Enforce that `noqa` annotations always occur with specific codes

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
* Dev dependencies were updated and re-pinned because why not? They were getting old enough. I'm just following along with the other repos.
* No cache used for pre-commit because it runs in a Docker container. I suppose it could be copied to the container from the cache on the host, but that doesn't seem worthwhile.