### PR TITLE
Document a simpler way to run snekbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,7 @@ result <- |             |<----------|           | <----------+
 
 ```
 
-The code is executed in a Python process that is launched through [NsJail], which is responsible for sandboxing the Python process. NsJail is configured as follows:
-
-* All mounts are read-only
-* Time limit of 5 seconds
-* Maximum of 1 PID
-* Maximum memory of 52428800 bytes
-* Loopback interface is down
-* procfs is disabled
-
-The Python process is configured as follows:
-
-* Version 3.8.0
-* Isolated mode
-  * Neither the script's directory nor the user's site packages are in `sys.path`
-  * All `PYTHON*` environment variables are ignored
+The code is executed in a Python process that is launched through [NsJail], which is responsible for sandboxing the Python process. See [`snekbox.cfg`] for the NsJail configuration.
 
 
 ## HTTP REST API
@@ -158,6 +144,7 @@ The alias can be found in `./scripts/.profile`, which is automatically added whe
 
 [1]: https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/Snekbox?branchName=master
 [2]: https://dev.azure.com/python-discord/Python%20Discord/_build/latest?definitionId=13&branchName=master
+[`snekbox.cfg`]: snekbox.cfg
 [`snekapi.py`]: snekbox/api/snekapi.py
 [`resources`]: snekbox/api/resources
 [`docker run`]: https://docs.docker.com/engine/reference/commandline/run/

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The HTML will output to `./htmlcov/` by default
 
 ### The `devsh` Helper Script
 
-This script starts an `bash` shell inside the venv Docker container and attaches to it. Unlike the production image, the venv image that is built by this script contains dev dependencies too. The project directory is mounted inside the container so any filesystem changes made inside the container affect the actual local project.
+This script starts a `bash` shell inside the venv Docker container and attaches to it. Unlike the production image, the venv image that is built by this script contains dev dependencies too. The project directory is mounted inside the container so any filesystem changes made inside the container affect the actual local project.
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/Snekbox?branchName=master)](https://dev.azure.com/python-discord/Python%20Discord/_build/latest?definitionId=13&branchName=master)
+[![Build Status][1]][2]
 
 # snekbox
 
@@ -22,7 +22,7 @@ result <- |             |<----------|           | <----------+
 
 ```
 
-The code is executed in a Python process that is launched through [NsJail](https://github.com/google/nsjail), which is responsible for sandboxing the Python process. NsJail is configured as follows:
+The code is executed in a Python process that is launched through [NsJail], which is responsible for sandboxing the Python process. NsJail is configured as follows:
 
 * All mounts are read-only
 * Time limit of 5 seconds
@@ -41,19 +41,19 @@ The Python process is configured as follows:
 
 ## HTTP REST API
 
-Communication with snekbox is done over a HTTP REST API. The framework for the HTTP REST API is [Falcon](https://falconframework.org/) and the WSGI being used is [Gunicorn](https://gunicorn.org/). By default, the server is hosted on `0.0.0.0:8060` with two workers.
+Communication with snekbox is done over a HTTP REST API. The framework for the HTTP REST API is [Falcon] and the WSGI being used is [Gunicorn]. By default, the server is hosted on `0.0.0.0:8060` with two workers.
 
-See [`snekapi.py`](snekbox/api/snekapi.py) and [`resources`](snekbox/api/resources) for API documentation.
+See [`snekapi.py`] and [`resources`] for API documentation.
 
 ## Running snekbox
 
-A Docker image is available on [Docker Hub](https://hub.docker.com/r/pythondiscord/snekbox). A container can be started with the following command, which will also pull the image if it doesn't currently exist locally:
+A Docker image is available on [Docker Hub]. A container can be started with the following command, which will also pull the image if it doesn't currently exist locally:
 
 ```
 docker run --ipc=none --privileged -p 8060:8060 pythondiscord/snekbox
 ```
 
-To run it in the background, use the `-d` option. See the documentation on [`docker run`](https://docs.docker.com/engine/reference/commandline/run/) for more information.
+To run it in the background, use the `-d` option. See the documentation on [`docker run`] for more information.
 
 The above command will make the API accessible on the host via `http://localhost:8060/`. Currently there's only one endpoint: `http://localhost:8060/eval`.
 
@@ -61,7 +61,7 @@ The above command will make the API accessible on the host via `http://localhost
 
 ### Initial Setup
 
-A Python 3.8 interpreter and the [pipenv](https://docs.pipenv.org/en/latest/) package are required. Once those requirements are satisfied, install the project's dependencies:
+A Python 3.8 interpreter and the [pipenv] package are required. Once those requirements are satisfied, install the project's dependencies:
 
 ```
 pipenv sync
@@ -155,3 +155,14 @@ nsjpy "print('hello world!')"
 ```
 
 The alias can be found in `./scripts/.profile`, which is automatically added when the shell is launched in the container.
+
+[1]: https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/Snekbox?branchName=master
+[2]: https://dev.azure.com/python-discord/Python%20Discord/_build/latest?definitionId=13&branchName=master
+[`snekapi.py`]: snekbox/api/snekapi.py
+[`resources`]: snekbox/api/resources
+[`docker run`]: https://docs.docker.com/engine/reference/commandline/run/
+[nsjail]: https://github.com/google/nsjail
+[falcon]: https://falconframework.org/
+[gunicorn]: https://gunicorn.org/
+[docker hub]: https://hub.docker.com/r/pythondiscord/snekbox
+[pipenv]: https://docs.pipenv.org/en/latest/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Communication with snekbox is done over a HTTP REST API. The framework for the H
 
 See [`snekapi.py`](snekbox/api/snekapi.py) and [`resources`](snekbox/api/resources) for API documentation.
 
+## Running snekbox
+
+A Docker image is available on [Docker Hub](https://hub.docker.com/r/pythondiscord/snekbox). A container can be started with the following command, which will also pull the image if it doesn't currently exist locally:
+
+```
+docker run --ipc=none --privileged -p 8060:8060 pythondiscord/snekbox
+```
+
+To run it in the background, use the `-d` option. See the documentation on [`docker run`](https://docs.docker.com/engine/reference/commandline/run/) for more information.
+
+The above command will make the API accessible on the host via `http://localhost:8060/`. Currently there's only one endpoint: `http://localhost:8060/eval`.
+
 ## Development Environment
 
 ### Initial Setup

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -32,20 +32,7 @@ class NsJail:
     """
     Core Snekbox functionality, providing safe execution of Python code.
 
-    Default NsJail configuration (snekbox.cfg):
-
-    - All mounts are read-only
-    - Time limit of 5 seconds
-    - Maximum of 1 PID
-    - Maximum memory of 52428800 bytes
-    - Loopback interface is down
-    - procfs is disabled
-
-    Python configuration:
-
-    - Isolated mode
-        - Neither the script's directory nor the user's site packages are in sys.path
-        - All PYTHON* environment variables are ignored
+    See snekbox.cfg for the default NsJail configuration.
     """
 
     def __init__(self, nsjail_binary: str = NSJAIL_PATH, python_binary: str = sys.executable):


### PR DESCRIPTION
Resolves #57 by adding a `docker run` command to README.md. Also included some other minor documentation improvements. See commit messages for more info.