### PR TITLE
add --dev flag to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The above command will make the API accessible on the host via `http://localhost
 A Python 3.8 interpreter and the [pipenv] package are required. Once those requirements are satisfied, install the project's dependencies:
 
 ```
-pipenv sync
+pipenv sync --dev
 ```
 
 Follow that up with setting up the pre-commit hook:


### PR DESCRIPTION
In the "development environment" section of the readme, it instructs to run `pipenv sync` to install dependencies and `pipenv run precommit` immediately after to install the pre-commit hooks. Since the `pre-commit` package (and related packages) is listed in the pipfile under `[dev-packages]`, this command fails.

Solution: instruct the user to install all dependencies with the `--dev` flag.