### PR TITLE
Support for running unix commands

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -57,6 +57,11 @@ testb = """
 report = "coverage report"
 snekbox = "gunicorn -c config/gunicorn.conf.py snekbox.api.app"
 devsh = "sh scripts/dev.sh"
+bootstrap-linux = """
+    sh -c ' \
+    mkdir linuxfs; \
+    debootstrap stable linuxfs http://deb.debian.org/debian/'
+"""
 build = """
     docker build \
         -t pythondiscord/snekbox:latest \

--- a/Pipfile
+++ b/Pipfile
@@ -57,11 +57,6 @@ testb = """
 report = "coverage report"
 snekbox = "gunicorn -c config/gunicorn.conf.py snekbox.api.app"
 devsh = "sh scripts/dev.sh"
-bootstrap-linux = """
-    sh -c ' \
-    mkdir linuxfs; \
-    debootstrap stable linuxfs http://deb.debian.org/debian/'
-"""
 build = """
     docker build \
         -t pythondiscord/snekbox:latest \

--- a/config/unixcmd.cfg
+++ b/config/unixcmd.cfg
@@ -1,0 +1,62 @@
+name: "unixcmd"
+description: "Execute Unix shell commands"
+
+mode: ONCE
+hostname: "snekbox"
+cwd: "/"
+
+time_limit: 6
+
+keep_env: false
+envar: "LANG=en_US.UTF-8"
+envar: "OMP_NUM_THREADS=1"
+envar: "OPENBLAS_NUM_THREADS=1"
+envar: "MKL_NUM_THREADS=1"
+envar: "VECLIB_MAXIMUM_THREADS=1"
+envar: "NUMEXPR_NUM_THREADS=1"
+
+keep_caps: false
+
+rlimit_as: 700
+
+clone_newnet: true
+clone_newuser: true
+clone_newns: true
+clone_newpid: true
+clone_newipc: true
+clone_newuts: true
+clone_newcgroup: true
+
+uidmap {
+    inside_id: "65534"
+    outside_id: "65534"
+}
+
+gidmap {
+    inside_id: "65534"
+    outside_id: "65534"
+}
+
+mount_proc: false
+
+mount {
+    src: "/snekbox/linuxfs"
+    dst: "/"
+    is_bind: true
+    rw: false
+}
+
+cgroup_mem_max: 52428800
+cgroup_mem_mount: "/sys/fs/cgroup/memory"
+cgroup_mem_parent: "NSJAIL"
+
+cgroup_pids_max: 10
+cgroup_pids_mount: "/sys/fs/cgroup/pids"
+cgroup_pids_parent: "NSJAIL"
+
+iface_no_lo: true
+
+exec_bin {
+    path: "/bin/bash"
+    arg: "-c"
+}

--- a/config/unixcmd.cfg
+++ b/config/unixcmd.cfg
@@ -9,11 +9,6 @@ time_limit: 6
 
 keep_env: false
 envar: "LANG=en_US.UTF-8"
-envar: "OMP_NUM_THREADS=1"
-envar: "OPENBLAS_NUM_THREADS=1"
-envar: "MKL_NUM_THREADS=1"
-envar: "VECLIB_MAXIMUM_THREADS=1"
-envar: "NUMEXPR_NUM_THREADS=1"
 
 keep_caps: false
 

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -y update \
         gcc=4:8.3.* \
         libnl-route-3-200=3.4.* \
         libprotobuf17=3.6.* \
+        debootstrap=1.0.* \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install pipenv==2018.11.26
 

--- a/docker/venv.Dockerfile
+++ b/docker/venv.Dockerfile
@@ -1,6 +1,7 @@
 FROM pythondiscord/snekbox-base:latest
 
 ARG DEV
+ARG NO_LINUXFS
 ENV PIP_NO_CACHE_DIR=false \
     PIPENV_DONT_USE_PYENV=1 \
     PIPENV_HIDE_EMOJIS=1 \
@@ -15,6 +16,8 @@ RUN if [ -n "${DEV}" ]; \
     else \
         pipenv install --deploy --system; \
     fi
+
+RUN [ -z "${NO_LINUXFS}" ] && pipenv run bootstrap-linux
 
 # At the end to avoid re-installing dependencies when only a config changes.
 COPY config/ /snekbox/config

--- a/docker/venv.Dockerfile
+++ b/docker/venv.Dockerfile
@@ -17,7 +17,11 @@ RUN if [ -n "${DEV}" ]; \
         pipenv install --deploy --system; \
     fi
 
-RUN [ -z "${NO_LINUXFS}" ] && pipenv run bootstrap-linux
+RUN if [ -z "${NO_LINUXFS}" ]; \
+    then \
+        mkdir linuxfs; \
+        debootstrap stable linuxfs http://deb.debian.org/debian/; \
+    fi
 
 # At the end to avoid re-installing dependencies when only a config changes.
 COPY config/ /snekbox/config

--- a/scripts/.profile
+++ b/scripts/.profile
@@ -15,7 +15,7 @@ nsjpy() {
     echo "${MEM_MAX}" > /sys/fs/cgroup/memory/NSJAIL/memory.memsw.limit_in_bytes
 
     nsjail \
-        --config "${NSJAIL_CFG:-/snekbox/config/snekbox.cfg}" \
+        --config "${NSJAIL_CFG_SNEKBOX:-/snekbox/config/snekbox.cfg}" \
         $nsj_args -- \
         /usr/local/bin/python -Iqu -c "$@"
 }

--- a/snekbox/api/resources/__init__.py
+++ b/snekbox/api/resources/__init__.py
@@ -1,3 +1,4 @@
 from .eval import EvalResource
+from .unixcmd import UnixCmdResource
 
-__all__ = ("EvalResource",)
+__all__ = ("EvalResource", "UnixCmdResource")

--- a/snekbox/api/resources/unixcmd.py
+++ b/snekbox/api/resources/unixcmd.py
@@ -44,7 +44,7 @@ class UnixCmdResource:
         Some noteworthy exceptions:
 
         - None
-            The NsJail process failed to launch
+            The NsJail process failed to launch. This will happen if LinuxFS is not set up.
         - 137 (SIGKILL)
             Typically because NsJail killed the Python process due to time or memory constraints
         - 255

--- a/snekbox/api/resources/unixcmd.py
+++ b/snekbox/api/resources/unixcmd.py
@@ -1,0 +1,86 @@
+import logging
+
+import falcon
+from falcon.media.validators.jsonschema import validate
+
+from snekbox.nsjail import NsJail
+
+log = logging.getLogger(__name__)
+
+
+class UnixCmdResource:
+    """
+    Evaluation of Unix commands.
+
+    Supported methods:
+
+    - POST /eval
+        Evaluate Unix command in bash and return the result
+    """
+
+    REQ_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "input": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "input"
+        ]
+    }
+
+    def __init__(self):
+        self.nsjail = NsJail()
+
+    @validate(REQ_SCHEMA)
+    def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """
+        Evaluate Unix commands in a bash shell and return stdout, stderr, and the return code.
+
+        The return code is that of the bash shell.
+        Commonly, bash returns the return code of the last executed command.
+
+        Some noteworthy exceptions:
+
+        - None
+            The NsJail process failed to launch
+        - 137 (SIGKILL)
+            Typically because NsJail killed the Python process due to time or memory constraints
+        - 255
+            NsJail encountered a fatal error
+
+        Request body:
+
+        >>> {
+        ...     "input": "echo $((1 + 1))"
+        ... }
+
+        Response format:
+
+        >>> {
+        ...     "stdout": "2\\n",
+        ...     "returncode": 0
+        ... }
+
+        Status codes:
+
+        - 200
+            Successful evaluation; not indicative that the input code itself works
+        - 400
+           Input's JSON schema is invalid
+        - 415
+            Unsupported content type; only application/JSON is supported
+        """
+        code = req.media["input"]
+
+        try:
+            result = self.nsjail.unix(code)
+        except Exception:
+            log.exception("An exception occurred while trying to process the request")
+            raise falcon.HTTPInternalServerError
+
+        resp.media = {
+            "stdout": result.stdout,
+            "returncode": result.returncode
+        }

--- a/snekbox/api/resources/unixcmd.py
+++ b/snekbox/api/resources/unixcmd.py
@@ -46,7 +46,7 @@ class UnixCmdResource:
         - None
             The NsJail process failed to launch. This will happen if LinuxFS is not set up.
         - 137 (SIGKILL)
-            Typically because NsJail killed the Python process due to time or memory constraints
+            Typically because NsJail killed the shell process due to time or memory constraints
         - 255
             NsJail encountered a fatal error
 

--- a/snekbox/api/snekapi.py
+++ b/snekbox/api/snekapi.py
@@ -1,6 +1,6 @@
 import falcon
 
-from .resources import EvalResource
+from .resources import EvalResource, UnixCmdResource
 
 
 class SnekAPI(falcon.API):
@@ -11,6 +11,8 @@ class SnekAPI(falcon.API):
 
     - /eval
         Evaluation of Python code
+    - /unixcmd
+        Evaluation of Linux commands in a bash shell
 
     Error response format:
 
@@ -24,3 +26,4 @@ class SnekAPI(falcon.API):
         super().__init__(*args, **kwargs)
 
         self.add_route("/eval", EvalResource())
+        self.add_route("/unixcmd", UnixCmdResource())

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -120,7 +120,6 @@ class NsJail:
                 f"--cgroup_mem_max={MEM_MAX}",
                 "--cgroup_mem_mount", str(CGROUP_MEMORY_PARENT.parent),
                 "--cgroup_mem_parent", CGROUP_MEMORY_PARENT.name,
-                "--cgroup_pids_max=10",
                 "--cgroup_pids_mount", str(CGROUP_PIDS_PARENT.parent),
                 "--cgroup_pids_parent", CGROUP_PIDS_PARENT.name,
                 "--"

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -22,12 +22,15 @@ LOG_BLACKLIST = ("Process will be ",)
 # Explicitly define constants for NsJail's default values.
 CGROUP_PIDS_PARENT = Path("/sys/fs/cgroup/pids/NSJAIL")
 CGROUP_MEMORY_PARENT = Path("/sys/fs/cgroup/memory/NSJAIL")
-
 NSJAIL_PATH = os.getenv("NSJAIL_PATH", "/usr/sbin/nsjail")
-NSJAIL_CFG_SNEKBOX = os.getenv("NSJAIL_CFG_SNEKBOX", "./config/snekbox.cfg")
 MEM_MAX = 52428800
 
+# python3-specifc configuration
+NSJAIL_CFG_SNEKBOX = os.getenv("NSJAIL_CFG_SNEKBOX", "./config/snekbox.cfg")
+
+# unix-specific configuration
 SHELL_PATH = os.getenv("SHELL_PATH", "/bin/bash")
+LINUXFS_DIR_PATH = os.getenv("LINUXFS_DIR_PATH", "/snekbox/linuxfs")
 NSJAIL_CFG_UNIXCMD = os.getenv("NSJAIL_CFG_UNIXCMD", "./config/unixcmd.cfg")
 
 
@@ -158,6 +161,10 @@ class NsJail:
 
     def unix(self, cmd: str) -> CompletedProcess:
         """Execute a unix command in an isolated system shell and return the completed process."""
+        if not Path(f"{LINUXFS_DIR_PATH}/{self.shell_binary}").is_file():
+            log.warning("Attempted to run Unix commands with no LinuxFS set up")
+            return CompletedProcess((), None, "LinuxFS not set up", None)
+
         args = (self.shell_binary, "-c", cmd)
 
         return self._jail_execute(NSJAIL_CFG_UNIXCMD, args)

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -10,14 +10,22 @@ class SnekAPITestCase(testing.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.patcher = mock.patch("snekbox.api.resources.eval.NsJail", autospec=True)
-        self.mock_nsjail = self.patcher.start()
-        self.mock_nsjail.return_value.python3.return_value = CompletedProcess(
+        self.python3_patcher = mock.patch("snekbox.api.resources.eval.NsJail", autospec=True)
+        self.unix_patcher = mock.patch("snekbox.api.resources.unixcmd.NsJail", autospec=True)
+
+        self.mock_eval_nsjail = self.python3_patcher.start()
+        self.mock_unixcmd_nsjail = self.unix_patcher.start()
+
+        mock_process = CompletedProcess(
             args=[],
             returncode=0,
             stdout="output",
             stderr="error"
         )
-        self.addCleanup(self.patcher.stop)
+        self.mock_eval_nsjail.return_value.python3.return_value = mock_process
+        self.mock_unixcmd_nsjail.return_value.unix.return_value = mock_process
+
+        self.addCleanup(self.python3_patcher.stop)
+        self.addCleanup(self.unix_patcher.stop)
 
         self.app = SnekAPI()

--- a/tests/api/test_unixcmd.py
+++ b/tests/api/test_unixcmd.py
@@ -1,0 +1,6 @@
+from .test_eval import TestEvalResource
+
+
+# `/eval` and `/unixcmd` should be kept the same, so tests should also be the same
+class TestUnixCmdResource(TestEvalResource):
+    PATH = "/unixcmd"

--- a/tests/nsjail/__init__.py
+++ b/tests/nsjail/__init__.py
@@ -1,0 +1,13 @@
+import logging
+import unittest
+
+from snekbox.nsjail import NsJail
+
+
+class NsJailTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.nsjail = NsJail()
+        self.nsjail.DEBUG = False
+        self.logger = logging.getLogger("snekbox.nsjail")

--- a/tests/nsjail/test_python3.py
+++ b/tests/nsjail/test_python3.py
@@ -1,18 +1,12 @@
-import logging
-import unittest
+from logging import DEBUG
 from textwrap import dedent
 
-from snekbox.nsjail import MEM_MAX, NsJail
+from tests.nsjail import NsJailTestCase
+
+from snekbox.nsjail import MEM_MAX
 
 
-class NsJailTests(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.nsjail = NsJail()
-        self.nsjail.DEBUG = False
-        self.logger = logging.getLogger("snekbox.nsjail")
-
+class Py3NsJailTests(NsJailTestCase):
     def test_print_returns_0(self):
         result = self.nsjail.python3("print('test')")
         self.assertEqual(result.returncode, 0)
@@ -113,7 +107,7 @@ class NsJailTests(unittest.TestCase):
             "Invalid Line"
         )
 
-        with self.assertLogs(self.logger, logging.DEBUG) as log:
+        with self.assertLogs(self.logger, DEBUG) as log:
             self.nsjail._parse_log(log_lines)
 
         self.assertIn("DEBUG:snekbox.nsjail:This is a debug message.", log.output)

--- a/tests/nsjail/test_unix.py
+++ b/tests/nsjail/test_unix.py
@@ -1,0 +1,82 @@
+from textwrap import dedent
+
+from tests.nsjail import NsJailTestCase
+
+from snekbox.nsjail import MEM_MAX
+
+
+class UnixNsJailTests(NsJailTestCase):
+    def test_echo_returns_0(self):
+        result = self.nsjail.unix("echo test")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "test\n")
+        self.assertEqual(result.stderr, None)
+
+    def test_timeout_returns_137(self):
+        cmd = dedent("""
+            sleep 10
+        """).strip()
+
+        with self.assertLogs(self.logger) as log:
+            result = self.nsjail.unix(cmd)
+
+        self.assertEqual(result.returncode, 137)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, None)
+        self.assertIn("run time >= time limit", "\n".join(log.output))
+
+    def test_no_alloc_over_mem_limit(self):
+        cmd = dedent(f"""
+            dd if=/dev/zero bs={MEM_MAX} count=1 | wc -c
+        """).strip()
+
+        result = self.nsjail.unix(cmd)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "0\n")
+        self.assertEqual(result.stderr, None)
+
+    def test_pid_limit(self):
+        # fixme: hardcoded pid limit
+        cmd = dedent("""
+            for i in {0..10}; do
+                sleep 2 &
+            done
+        """)
+
+        result = self.nsjail.unix(cmd)
+        self.assertEqual(result.returncode, 254)
+        self.assertIn("Resource temporarily unavailable", result.stdout)
+        self.assertEqual(result.stderr, None)
+
+    def test_mtab_not_available(self):
+        cmd = dedent("""
+            mount
+        """)
+
+        result = self.nsjail.unix(cmd)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "mount: failed to read mtab: No such file or directory\n")
+        self.assertEqual(result.stderr, None)
+
+    def test_readonly_filesystem(self):
+        cmd = dedent("""
+            for location in "/ /dev /tmp /proc /bin"; do
+                touch $location/test 2>/dev/null
+                [ $? -eq 0 ] && echo Success
+            done
+        """)
+
+        result = self.nsjail.unix(cmd)
+        self.assertEqual(result.returncode, 1)
+        self.assertNotIn("Success", result.stdout)
+        self.assertEqual(result.stderr, None)
+
+    def test_cannot_remount_rootfs(self):
+        cmd = dedent("""
+            mount / /
+        """)
+
+        result = self.nsjail.unix(cmd)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "mount: only root can do that\n")
+        self.assertEqual(result.stderr, None)

--- a/tests/nsjail/test_unix.py
+++ b/tests/nsjail/test_unix.py
@@ -80,3 +80,17 @@ class UnixNsJailTests(NsJailTestCase):
         self.assertEqual(result.returncode, 1)
         self.assertEqual(result.stdout, "mount: only root can do that\n")
         self.assertEqual(result.stderr, None)
+
+    def test_fail_gracefully_when_linuxfs_not_setup(self):
+        orig_binary = self.nsjail.shell_binary
+        self.nsjail.shell_binary = "/nonexistent/path"
+        cmd = dedent("""
+            whoami
+        """)
+
+        result = self.nsjail.unix(cmd)
+        self.assertEqual(result.returncode, None)
+        self.assertEqual(result.stdout, "LinuxFS not set up")
+        self.assertEqual(result.stderr, None)
+
+        self.nsjail.shell_binary = orig_binary  # clean up


### PR DESCRIPTION
### Description
This is a patchset to utilise snekbox to run Unix commands (namely GNU/Linux Debian stable).

### Implementation
It implements a new API endpoint `/unixcmd`, the usage of which is analogue to the already existing `/eval` endpoint - but instead of evaluating the `input` parameter value as Python code, it is executed in a real Linux environment in a bash shell. As with `/eval`, it returns `output` with the combined output of `stdout` and `stderr` and whatever return code bash returned, which is usually the return code of the last command executed.

Currently, this is implemented using a Debian root filesystem. When building the `venv` Docker image, unless the variable `NO_LINUXFS` is set, `debootstrap` is used to bootstrap a Debian stable image into `/snekbox/linuxfs`. When `/unixcmd` is called, snekbox instructs NsJail to bind this directory as `/` (as read-only) and run its `/bin/bash`. 

It should be noted this environment is technically and practically different than the one snekbox evaluates Python code in. The main differences are that the maximum PID (process) count is increased to 10, which is a design requirement (bash would be unable to run anything otherwise), and that this environment has a _full_ filesystem hierarchy as opposed to just the files that snekbox needs to run Python. As such, I feel comfortable only letting a higher rank such as Helpers+ run this command, but that is a bot interface implementation detail rather than snekbox's.

### Rationale
I've noticed that there are a lot of times in the `#unix` channel when someone asks for help with something which could easily be demonstrated on a "real" Unix system, but harder to explain as a concept. This feature would be useful in such cases.

### Example usage
Request:
```http
POST /unixcmd HTTP/1.1
Host: localhost:8060
Content-Type: application/json
Content-Length: 24

{"input":"id; uname -a"}
```

Response:
```http
HTTP/1.1 200 OK
Server: gunicorn/19.10.0
Date: Mon, 30 Mar 2020 16:01:11 GMT
Connection: close
content-type: application/json
content-length: 185

{"stdout": "uid=65534(nobody) gid=65534(nogroup) groups=65534(nogroup)\nLinux snekbox 5.5.11-arch1-1 #1 SMP PREEMPT Sun, 22 Mar 2020 16:33:15 +0000 x86_64 GNU/Linux\n", "returncode": 0}
```

### To-Do
- [x] fix broken test `test_subprocess_resource_unavailable` (do not pass PID count as nsjail argument)
- [x] write tests for new code
- [ ] Bash prints "Resource temporarily unavailable" three times before exiting when NsJail limits are hit (time limit, pid limit). Need to find a way to display this in a user-friendly manner
- [x] write logic for when `/unixcmd` is called when no linuxfs is set up. Currently, NsJail returns blank output and return code -1 (255)
- [ ] create PR for bot interface implementation
- [ ] `UnixCmdResource` and `EvalResource` are the same apart from the nsjail function being called. Find a way to remove duplication
- [x] fix logparser logic
- [ ] update documentation

Comments, ideas, criticism, etc all very welcome.