### PR TITLE
Limit STDOUT to prevent OOM events in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ result <- |             |<----------|           | <----------+
 
 The code is executed in a Python process that is launched through [NsJail], which is responsible for sandboxing the Python process. See [`snekbox.cfg`] for the NsJail configuration.
 
+The output returned by snekbox is truncated at around 1 MB.
 
 ## HTTP REST API
 

--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -18,7 +18,6 @@ envar: "NUMEXPR_NUM_THREADS=1"
 keep_caps: false
 
 rlimit_as: 700
-rlimit_fsize: 10
 
 clone_newnet: true
 clone_newuser: true

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -122,7 +122,7 @@ class NsJail:
 
         # We'll consume STDOUT as long as the NsJail subprocess is running.
         while nsjail.poll() is None:
-            chars = nsjail.stdout.read(100)
+            chars = nsjail.stdout.read(10_000)
             output_size += sys.getsizeof(chars)
             output.append(chars)
 

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -112,7 +112,7 @@ class NsJail:
         The aim of this function is to limit the size of the output received from
         NsJail to prevent container from claiming too much memory. If the output
         received from STDOUT goes over the OUTPUT_MAX limit, the NsJail subprocess
-        is asked to terminate with a SIGTERM.
+        is asked to terminate with a SIGKILL.
 
         Once the subprocess has exited, either naturally or because it was terminated,
         the output up to that point is returned as a string.
@@ -127,8 +127,8 @@ class NsJail:
             output.append(chars)
 
             if output_size > OUTPUT_MAX:
-                # Ask NsJail to terminate as we've gone over the output limit.
-                nsjail.terminate()
+                # Terminate the NsJail subprocess with SIGKILL.
+                nsjail.kill()
                 break
 
         # Ensure that we wait for the NsJail subprocess to terminate.

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -116,7 +116,7 @@ class NsJail:
         is asked to terminate with a SIGKILL.
 
         Once the subprocess has exited, either naturally or because it was terminated,
-        we rturn the output as a single string.
+        we return the output as a single string.
         """
         output_size = 0
         output = []

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -120,22 +120,18 @@ class NsJail:
         output_size = 0
         output = []
 
-        # We'll consume STDOUT as long as the NsJail subprocess is running
+        # We'll consume STDOUT as long as the NsJail subprocess is running.
         while nsjail.poll() is None:
-            # Read 100 characters from the STDOUT stream
             chars = nsjail.stdout.read(100)
-            chars_size = sys.getsizeof(chars)
+            output_size += sys.getsizeof(chars)
+            output.append(chars)
 
-            # Check if these characters take us over the output limit
-            if output_size + chars_size > OUTPUT_MAX:
-                # Ask nsjail to terminate itself using SIGTERM
+            if output_size > OUTPUT_MAX:
+                # Ask NsJail to terminate as we've gone over the output limit.
                 nsjail.terminate()
                 break
 
-            output_size += chars_size
-            output.append(chars)
-
-        # Ensure that we wait for the nsjail process to terminate
+        # Ensure that we wait for the NsJail subprocess to terminate.
         nsjail.wait()
 
         return "".join(output)

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -29,6 +29,7 @@ MEM_MAX = 52428800
 
 # Limit of stdout bytes we consume before terminating nsjail
 OUTPUT_MAX = 1_000_000  # 1 MB
+READ_CHUNK_SIZE = 10_000  # chars
 
 
 class NsJail:
@@ -122,7 +123,7 @@ class NsJail:
 
         # We'll consume STDOUT as long as the NsJail subprocess is running.
         while nsjail.poll() is None:
-            chars = nsjail.stdout.read(10_000)
+            chars = nsjail.stdout.read(READ_CHUNK_SIZE)
             output_size += sys.getsizeof(chars)
             output.append(chars)
 

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -174,3 +174,12 @@ class NsJailTests(unittest.TestCase):
             msg="stdout does not come before stderr"
         )
         self.assertEqual(result.stderr, None)
+
+    def test_stdout_flood_results_in_graceful_sigterm(self):
+        stdout_flood = dedent("""
+            while True:
+                print('abcdefghij')
+        """).strip()
+
+        result = self.nsjail.python3(stdout_flood)
+        self.assertEqual(result.returncode, 143)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -5,7 +5,7 @@ import unittest
 import unittest.mock
 from textwrap import dedent
 
-from snekbox.nsjail import MEM_MAX, NsJail, READ_CHUNK_SIZE, OUTPUT_MAX
+from snekbox.nsjail import MEM_MAX, NsJail, OUTPUT_MAX, READ_CHUNK_SIZE
 
 
 class NsJailTests(unittest.TestCase):
@@ -195,9 +195,7 @@ class NsJailTests(unittest.TestCase):
 
         # Go 10 chunks over to make sure we exceed the limit
         nsjail_subprocess.stdout = io.StringIO((expected_chunks + 10) * chunk)
-        nsjail_subprocess.returncode = -9
         nsjail_subprocess.poll.return_value = None
 
-        returncode, output = self.nsjail._consume_stdout(nsjail_subprocess)
-        self.assertEqual(returncode, 137)
+        output = self.nsjail._consume_stdout(nsjail_subprocess)
         self.assertEqual(output, chunk * expected_chunks)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -182,4 +182,4 @@ class NsJailTests(unittest.TestCase):
         """).strip()
 
         result = self.nsjail.python3(stdout_flood)
-        self.assertEqual(result.returncode, -9)
+        self.assertEqual(result.returncode, 137)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -182,4 +182,4 @@ class NsJailTests(unittest.TestCase):
         """).strip()
 
         result = self.nsjail.python3(stdout_flood)
-        self.assertEqual(result.returncode, 143)
+        self.assertEqual(result.returncode, -9)


### PR DESCRIPTION
Recently, we discovered that for some code inputs, snekbox would get into an OOM event on the container level, seemingly bypassing the memory restrictions laid on code execution by NSJail.

After investigating the issue, we identified the culprit to be the STDOUT pipe we use to get output back from NSJail: As output is piped out of the jailed process, it will be collected outside of the NSJail in the main container process instead. This meant that our initial attempts of limiting the allowed filesize within the NSJail failed, as the OOM happened outside of the jailed environment.

To mitigate the issue, I've written a loop that consumes the STDOUT pipe in chunks of 100 characters. Once the size of the accrued output reaches a certain limit (currently set to 1 MB), we send a SIGTERM signal to NSJail to terminate itself. The output up to that point will be relayed back to the caller.

A minimal code snippet to trigger the event and the mitigation:

```py
while True:
    print("1234567890")
```

I've included a test for this vulnerability in [`tests/test_nsjail.py`](https://github.com/python-discord/snekbox/blob/5639a400e633a48c8564a61a035485933229d4f5/tests/test_nsjail.py#L178).