### PR TITLE
Implement Sentry releases

### DIFF
--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -170,6 +170,8 @@ jobs:
           tags: |
             ghcr.io/python-discord/snekbox:latest
             ghcr.io/python-discord/snekbox:${{ steps.sha_tag.outputs.tag }}
+          build-args: |
+            git_sha=${{ GITHUB_SHA }}
 
       # Deploy to Kubernetes
       - name: Authenticate with Kubernetes

--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -171,7 +171,7 @@ jobs:
             ghcr.io/python-discord/snekbox:latest
             ghcr.io/python-discord/snekbox:${{ steps.sha_tag.outputs.tag }}
           build-args: |
-            git_sha=${{ GITHUB_SHA }}
+            git_sha=${{ github.sha }}
 
       # Deploy to Kubernetes
       - name: Authenticate with Kubernetes

--- a/.github/workflows/sentry_release.yaml
+++ b/.github/workflows/sentry_release.yaml
@@ -1,0 +1,24 @@
+name: Create Sentry release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create_sentry_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Create a Sentry.io release
+        uses: tclindner/sentry-releases-action@v1.2.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: python-discord
+          SENTRY_PROJECT: snekbox
+        with:
+          tagName: ${{ github.sha }}
+          environment: production
+          releaseNamePrefix: snekbox@

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,13 @@ RUN chmod +x /usr/sbin/nsjail
 
 FROM base as venv
 ARG DEV
+ARG git_sha="development"
 
 ENV PIP_NO_CACHE_DIR=false \
     PIPENV_DONT_USE_PYENV=1 \
     PIPENV_HIDE_EMOJIS=1 \
-    PIPENV_NOSPIN=1
+    PIPENV_NOSPIN=1 \
+    GIT_SHA=$git_sha
 
 COPY Pipfile Pipfile.lock /snekbox/
 WORKDIR /snekbox

--- a/snekbox/__init__.py
+++ b/snekbox/__init__.py
@@ -8,11 +8,13 @@ from gunicorn.config import Config
 from sentry_sdk.integrations.falcon import FalconIntegration
 
 DEBUG = os.environ.get("DEBUG", False)
+GIT_SHA = os.environ.get("GIT_SHA", "development")
 
 sentry_sdk.init(
     dsn=os.environ.get("SNEKBOX_SENTRY_DSN", ""),
     integrations=[FalconIntegration()],
-    send_default_pii=True
+    send_default_pii=True,
+    release=f"snekbox@{GIT_SHA}"
 )
 
 


### PR DESCRIPTION
Added injecting Git SHA to container using build arguments. On SDK initialization this uses this SHA for release defining. Also added workflow for creating releases.