### PR TITLE
 Fix caching of exposed packages

### DIFF
--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -108,11 +108,12 @@ jobs:
           docker exec snekbox_test /bin/bash -c
           'apt-get -y update && apt-get install -y git=1:2.20.*'
 
+      # pre-commit's venv doesn't work with user installs.
       # Skip the flake8 hook because the following step will run it.
       - name: Run pre-commit hooks
         run: >-
           docker exec snekbox_test /bin/bash -c
-          'SKIP=flake8 pre-commit run --all-files'
+          'PIP_USER=0 SKIP=flake8 pre-commit run --all-files'
 
       # This runs `flake8` in the container and asks `flake8` to output
       # linting errors in the format of the command for registering workflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN git clone \
 WORKDIR /nsjail
 RUN make
 
+# ------------------------------------------------------------------------------
 FROM python:3.9-slim-buster as base
 ENV PIP_NO_CACHE_DIR=false \
     PIPENV_DONT_USE_PYENV=1 \
@@ -37,6 +38,7 @@ RUN pip install pipenv==2020.11.4
 COPY --from=builder /nsjail/nsjail /usr/sbin/
 RUN chmod +x /usr/sbin/nsjail
 
+# ------------------------------------------------------------------------------
 FROM base as venv
 ARG DEV
 
@@ -60,6 +62,7 @@ RUN if [ -n "${DEV}" ]; \
 # It's in the venv image because the final image is not used during development.
 COPY config/ /snekbox/config
 
+# ------------------------------------------------------------------------------
 FROM venv
 
 ENTRYPOINT ["gunicorn"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ WORKDIR /nsjail
 RUN make
 
 FROM python:3.9-slim-buster as base
-ENV PIP_NO_CACHE_DIR=false
+ENV PIP_NO_CACHE_DIR=false \
+    PIPENV_DONT_USE_PYENV=1 \
+    PIPENV_HIDE_EMOJIS=1 \
+    PIPENV_NOSPIN=1 \
+    PYTHONUSERBASE=/snekbox/user_base
 
 RUN apt-get -y update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get -y update \
         libnl-route-3-200=3.4.* \
         libprotobuf17=3.6.* \
     && rm -rf /var/lib/apt/lists/*
-RUN pip install pipenv==2020.11.4
+RUN pip install pipenv==2020.11.15
 
 COPY --from=builder /nsjail/nsjail /usr/sbin/
 RUN chmod +x /usr/sbin/nsjail

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,7 @@ ENV PIP_NO_CACHE_DIR=false \
 COPY Pipfile Pipfile.lock /snekbox/
 WORKDIR /snekbox
 
-RUN if [ -n "${DEV}" ]; \
-    then \
-        pipenv install --deploy --system --dev; \
-    else \
-        pipenv install --deploy --system; \
-    fi
+RUN pipenv install --deploy --system ${DEV:+--dev}
 
 # At the end to avoid re-installing dependencies when only a config changes.
 # It's in the venv image because the final image is not used during development.

--- a/README.md
+++ b/README.md
@@ -50,19 +50,17 @@ By default, the Python interpreter has no access to any packages besides the
 standard library. Even snekbox's own dependencies like Falcon and Gunicorn are
 not exposed.
 
-To expose third-party Python packages during evaluation, install them to the user site:
+To expose third-party Python packages during evaluation, install them to a custom user site:
 
 ```sh
-docker exec snekbox /bin/sh -c 'pip install --ignore-installed --user numpy'
+docker exec snekbox /bin/sh -c 'PYTHONUSERBASE=/snekbox/user_base pip install numpy'
 ```
 
 In the above command, `snekbox` is the name of the running container. The name may be different and can be checked with `docker ps`.
 
-It's important to use `--user` to install them to the user site, whose base is located at `/snekbox/user_base` within the Docker container. To persist the installed packages, a volume for the directory can be created with Docker. For an example, see [`docker-compose.yml`].
+The packages will be installed to the user site within `/snekbox/user_base`. To persist the installed packages, a volume for the directory can be created with Docker. For an example, see [`docker-compose.yml`].
 
-`--ignore-installed` is only necessary if installing a package that happens to
-be a dependency of snekbox. Normally, pip would reject the installation because
-it doesn't make a distinction here between the global and user sites.
+If `pip`, `setuptools`, or `wheel` are dependencies or need to be exposed, then use the `--ignore-installed` option with pip. However, note that this will also re-install packages present in the custom user site, effectively making caching it futile. Current limitations of pip don't allow it to ignore packages extant outside the installation destination.
 
 ## Development Environment
 

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -30,7 +30,8 @@ spec:
                   - "/bin/sh"
                   - "-c"
                   - >-
-                    pip install --user --ignore-installed
+                    PYTHONUSERBASE=/snekbox/user_base
+                    pip install --user
                     arrow~=0.17
                     attrs~=20.3
                     beautifulsoup4~=4.9


### PR DESCRIPTION
Fix #89

The problem with `--ignore-installed` is that it also ignores packages in the target site, therefore re-installing all packages and making caching futile.

Install snekbox's dependencies to the default user site. During installation of the exposed packages, switch the user site to a custom one to ensure pip will not skip packages due to seeing them as already installed as one of snekbox's dependencies.

If pip made the `--root` option ignore packages outside the root, then using `--root` would be the best solution. There is a 5+ year old issue open about that.

There is also some refactoring of the Dockerfile.