### PR TITLE
Remove all child cgroups before removing parents

### DIFF
--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -224,6 +224,18 @@ class NsJail:
 
         log.info(f"nsjail return code: {returncode}")
 
+        # If we hit a cgroup limit then there is a chance the nsjail cgroups did not
+        # get removed. If we don't remove them then when we try remove the parents
+        # we will get a "Device or resource busy" error.
+
+        children = []
+
+        children.extend(Path(self.config.cgroup_mem_mount, cgroup).glob("NSJAIL.*"))
+        children.extend(Path(self.config.cgroup_pids_mount, cgroup).glob("NSJAIL.*"))
+
+        for child in children:
+            child.rmdir()
+
         # Remove the dynamically created cgroups once we're done
         Path(self.config.cgroup_mem_mount, cgroup).rmdir()
         Path(self.config.cgroup_pids_mount, cgroup).rmdir()


### PR DESCRIPTION
After #91 was merged we starting seeing errors with large stdout causing errors like the following:
```
2021-02-26 16:02:56,706 |    14 |                 snekbox.nsjail |     INFO | Executing code...
2021-02-26 16:02:56,741 |    14 |                 snekbox.nsjail |     INFO | Output exceeded the output limit, sending SIGKILL to NsJail.
2021-02-26 16:02:56,743 |    14 |                 snekbox.nsjail |     INFO | nsjail return code: 137
2021-02-26 16:02:56,744 |    14 |     snekbox.api.resources.eval |    ERROR | An exception occurred while trying to process the request
Traceback (most recent call last):
  File "/snekbox/snekbox/api/resources/eval.py", line 75, in on_post
    result = self.nsjail.python3(code)
  File "/snekbox/snekbox/nsjail.py", line 228, in python3
    Path(self.config.cgroup_mem_mount, cgroup).rmdir()
  File "/usr/local/lib/python3.9/pathlib.py", line 1352, in rmdir
    self._accessor.rmdir(self)
OSError: [Errno 16] Device or resource busy: '/sys/fs/cgroup/memory/snekbox-87fd27a1-d0e9-4387-8160-8d1a985d43e4'
```

I think that this external killing of nsjail does not let it clear up the child cgroup (which resides in a directory like `/sys/fs/cgroup/memory/snekbox-87fd27a1-d0e9-4387-8160-8d1a985d43e4/NSJAIL.12`). Once nsjail exits we then try to clear up the parent cgroup (in the example, `/sys/fs/cgroup/memory/snekbox-87fd27a1-d0e9-4387-8160-8d1a985d43e4`) which cannot succeed because the child cgroup exists.

This PR fixes that by removing the child cgroup before attempting to remove the parent, therefore recursively clearing the tree and ensuring that no cgroup can be busy.

My understanding is that it's safe to remove that cgroup (which I think technically removes the limits from nsjail) because by the point this code is reached the execution has either finished or has been killed.