### PR TITLE
nsjail SIGKILL to SIGTERM

### DIFF
--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -224,18 +224,6 @@ class NsJail:
 
         log.info(f"nsjail return code: {returncode}")
 
-        # If we hit a cgroup limit then there is a chance the nsjail cgroups did not
-        # get removed. If we don't remove them then when we try remove the parents
-        # we will get a "Device or resource busy" error.
-
-        children = []
-
-        children.extend(Path(self.config.cgroup_mem_mount, cgroup).glob("NSJAIL.*"))
-        children.extend(Path(self.config.cgroup_pids_mount, cgroup).glob("NSJAIL.*"))
-
-        for child in children:
-            child.rmdir()
-
         # Remove the dynamically created cgroups once we're done
         Path(self.config.cgroup_mem_mount, cgroup).rmdir()
         Path(self.config.cgroup_pids_mount, cgroup).rmdir()

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -163,9 +163,10 @@ class NsJail:
                 output.append(chars)
 
                 if output_size > OUTPUT_MAX:
-                    # Terminate the NsJail subprocess with SIGKILL.
-                    log.info("Output exceeded the output limit, sending SIGKILL to NsJail.")
-                    nsjail.kill()
+                    # Terminate the NsJail subprocess with SIGTERM.
+                    # This in turn reaps and kills children with SIGKILL.
+                    log.info("Output exceeded the output limit, sending SIGTERM to NsJail.")
+                    nsjail.terminate()
                     break
 
         return "".join(output)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -186,7 +186,7 @@ class NsJailTests(unittest.TestCase):
         """).strip()
 
         result = self.nsjail.python3(stdout_flood)
-        self.assertEqual(result.returncode, 137)
+        self.assertEqual(result.returncode, 143)
 
     def test_large_output_is_truncated(self):
         chunk = "a" * READ_CHUNK_SIZE


### PR DESCRIPTION
As of now, when an evaluation exceeds a write buffer limit we send SIGKILL to the nsjail parent process. This does not give nsjail a chance to perform cleanups such as removing generated cgroups. It also leaves child processes in a running state which then means that further removal of cgroups manually is not possible without becoming a subreaper and killing them manually (see #95).

This PR changes the signal to SIGTERM which triggers nsjail's cleanup logic such as removing cgroups and other cleanup, such as reaping child processes and distributing SIGKILL to them. For more information Mark's comment on #95 goes into the nitty-gritty on the implementation of this logic in nsjail.