### PR TITLE
feat: Allow custom arguments to be passed to eval

### DIFF
--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -95,9 +95,16 @@ jobs:
       # pre-commit's venv doesn't work with user installs.
       # Skip the flake8 hook because the following step will run it.
       - name: Run pre-commit hooks
+        id: run-pre-commit-hooks
         run: >-
           docker exec snekbox_dev /bin/bash -c
           'PIP_USER=0 SKIP=flake8 pre-commit run --all-files'
+
+      - name: Show pre-commit logs
+        if: always() && steps.run-pre-commit-hooks.outcome != 'success'
+        run: >-
+          docker exec snekbox_dev /bin/bash -c
+          'cat /root/.cache/pre-commit/pre-commit.log'
 
       # This runs `flake8` in the container and asks `flake8` to output
       # linting errors in the format of the command for registering workflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       cache_from:
         - ghcr.io/python-discord/snekbox:latest
     volumes:
-      - .:/snekbox
+      - $PWD:$PWD
       - user-base:/snekbox/user_base
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       cache_from:
         - ghcr.io/python-discord/snekbox:latest
     volumes:
-      - $PWD:$PWD
+      - .:/snekbox
       - user-base:/snekbox/user_base
 
 volumes:

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -44,7 +44,9 @@ class EvalResource:
         """
         Evaluate Python code and return stdout, stderr, and the return code.
 
-        The optional `args` parameter can be passed, and it would replace the "-c" option.
+        A list of arguments for the Python subprocess can be specified as `args`.
+        Otherwise, the default argument "-c" is used to execute the input code.
+        The input code is always passed as the last argument to Python.
 
         The return codes mostly resemble those of a Unix shell. Some noteworthy cases:
 

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -26,7 +26,7 @@ class EvalResource:
             },
             "args": {
                 "type": "array",
-                "contains": {
+                "items": {
                     "type": "string"
                 }
             }
@@ -44,6 +44,8 @@ class EvalResource:
         """
         Evaluate Python code and return stdout, stderr, and the return code.
 
+        The optional `args` parameter can be passed, and it woul replace the "-c" option.
+
         The return codes mostly resemble those of a Unix shell. Some noteworthy cases:
 
         - None
@@ -56,14 +58,14 @@ class EvalResource:
         Request body:
 
         >>> {
-        ...     "input": "print(1 + 1)"
+        ...     "input": "[i for i in range(1000)]",
         ...     "args": ["-m", "timeit"] # This is optional
         ... }
 
         Response format:
 
         >>> {
-        ...     "stdout": "2\\n",
+        ...     "10000 loops, best of 5: 23.8 usec per loop\n",
         ...     "returncode": 0
         ... }
 
@@ -80,7 +82,7 @@ class EvalResource:
         args = req.media.get("args", ("-c",))
 
         try:
-            result = self.nsjail.python3(code, extra_args=args)
+            result = self.nsjail.python3(code, py_args=args)
         except Exception:
             log.exception("An exception occurred while trying to process the request")
             raise falcon.HTTPInternalServerError

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -23,6 +23,12 @@ class EvalResource:
         "properties": {
             "input": {
                 "type": "string"
+            },
+            "args": {
+                "type": "array",
+                "contains": {
+                    "type": "string"
+                }
             }
         },
         "required": [
@@ -51,6 +57,7 @@ class EvalResource:
 
         >>> {
         ...     "input": "print(1 + 1)"
+        ...     "args": ["-m", "timeit"] # This is optional
         ... }
 
         Response format:
@@ -70,9 +77,10 @@ class EvalResource:
             Unsupported content type; only application/JSON is supported
         """
         code = req.media["input"]
+        args = req.media.get("args", ("-c",))
 
         try:
-            result = self.nsjail.python3(code)
+            result = self.nsjail.python3(code, extra_args=args)
         except Exception:
             log.exception("An exception occurred while trying to process the request")
             raise falcon.HTTPInternalServerError

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -44,7 +44,7 @@ class EvalResource:
         """
         Evaluate Python code and return stdout, stderr, and the return code.
 
-        The optional `args` parameter can be passed, and it woul replace the "-c" option.
+        The optional `args` parameter can be passed, and it would replace the "-c" option.
 
         The return codes mostly resemble those of a Unix shell. Some noteworthy cases:
 
@@ -65,7 +65,7 @@ class EvalResource:
         Response format:
 
         >>> {
-        ...     "10000 loops, best of 5: 23.8 usec per loop\n",
+        ...     "stdout": "10000 loops, best of 5: 23.8 usec per loop\n",
         ...     "returncode": 0
         ... }
 

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -181,7 +181,7 @@ class NsJail:
         """
         Execute Python 3 code in an isolated environment and return the completed process.
 
-        Additional arguments passed will be used to override the values in the NsJail config.
+        The `nsjail_args` passed will be used to override the values in the NsJail config.
         These arguments are only options for NsJail; they do not affect Python's arguments.
 
         The `py_args` keyword argument can be given, and this would replace the "-c" argument

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -184,8 +184,8 @@ class NsJail:
         The `nsjail_args` passed will be used to override the values in the NsJail config.
         These arguments are only options for NsJail; they do not affect Python's arguments.
 
-        The `py_args` keyword argument can be given, and this would replace the "-c" argument
-        given by default.
+        `py_args` are arguments to pass to the Python subprocess before the code,
+        which is the last argument. By default, it's "-c", which executes the code given.
         """
         cgroup = self._create_dynamic_cgroups()
 

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -171,12 +171,15 @@ class NsJail:
 
         return "".join(output)
 
-    def python3(self, code: str, *args) -> CompletedProcess:
+    def python3(self, code: str, *args, extra_args: Iterable[str] = ("-c",)) -> CompletedProcess:
         """
         Execute Python 3 code in an isolated environment and return the completed process.
 
         Additional arguments passed will be used to override the values in the NsJail config.
         These arguments are only options for NsJail; they do not affect Python's arguments.
+
+        The `extra_args` keyword argument can be given, and this would replace the "-c" argument
+        given by default.
         """
         cgroup = self._create_dynamic_cgroups()
 
@@ -190,7 +193,7 @@ class NsJail:
                 "--cgroup_pids_parent", cgroup,
                 *args,
                 "--",
-                self.config.exec_bin.path, *self.config.exec_bin.arg, "-c", code
+                self.config.exec_bin.path, *self.config.exec_bin.arg, *extra_args, code
             )
 
             msg = "Executing code..."

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -171,14 +171,20 @@ class NsJail:
 
         return "".join(output)
 
-    def python3(self, code: str, *args, extra_args: Iterable[str] = ("-c",)) -> CompletedProcess:
+    def python3(
+        self,
+        code: str,
+        *,
+        nsjail_args: Iterable[str] = (),
+        py_args: Iterable[str] = ("-c",)
+    ) -> CompletedProcess:
         """
         Execute Python 3 code in an isolated environment and return the completed process.
 
         Additional arguments passed will be used to override the values in the NsJail config.
         These arguments are only options for NsJail; they do not affect Python's arguments.
 
-        The `extra_args` keyword argument can be given, and this would replace the "-c" argument
+        The `py_args` keyword argument can be given, and this would replace the "-c" argument
         given by default.
         """
         cgroup = self._create_dynamic_cgroups()
@@ -191,9 +197,9 @@ class NsJail:
                 # Set our dynamically created parent cgroups
                 "--cgroup_mem_parent", cgroup,
                 "--cgroup_pids_parent", cgroup,
-                *args,
+                *nsjail_args,
                 "--",
-                self.config.exec_bin.path, *self.config.exec_bin.arg, *extra_args, code
+                self.config.exec_bin.path, *self.config.exec_bin.arg, *py_args, code
             )
 
             msg = "Executing code..."

--- a/tests/api/test_eval.py
+++ b/tests/api/test_eval.py
@@ -26,22 +26,22 @@ class TestEvalResource(SnekAPITestCase):
         self.assertEqual(expected, result.json)
 
     def test_post_invalid_data_400(self):
-        input_body = {"input": 400}
-        args_body = {"input": "", "args": [400]}
+        bodies = (
+            {"input": 400}, {"input": "", "args": [400]}
+        )
 
-        input_result = self.simulate_post(self.PATH, json=input_body)
-        args_result = self.simulate_post(self.PATH, json=args_body)
+        for body in bodies:
+            with self.subTest():
+                result = self.simulate_post(self.PATH, json=body)
 
-        self.assertEqual(input_result.status_code, 400)
-        self.assertEqual(args_result.status_code, 400)
+                self.assertEqual(result.status_code, 400)
 
-        expected = {
-            "title": "Request data failed validation",
-            "description": "400 is not of type 'string'"
-        }
+                expected = {
+                    "title": "Request data failed validation",
+                    "description": "400 is not of type 'string'"
+                }
 
-        self.assertEqual(expected, input_result.json)
-        self.assertEqual(expected, args_result.json)
+                self.assertEqual(expected, result.json)
 
     def test_post_invalid_content_type_415(self):
         body = "{'input': 'foo'}"

--- a/tests/api/test_eval.py
+++ b/tests/api/test_eval.py
@@ -25,6 +25,24 @@ class TestEvalResource(SnekAPITestCase):
 
         self.assertEqual(expected, result.json)
 
+    def test_post_invalid_data_400(self):
+        input_body = {"input": 400}
+        args_body = {"input": "", "args": [400]}
+
+        input_result = self.simulate_post(self.PATH, json=input_body)
+        args_result = self.simulate_post(self.PATH, json=args_body)
+
+        self.assertEqual(input_result.status_code, 400)
+        self.assertEqual(args_result.status_code, 400)
+
+        expected = {
+            "title": "Request data failed validation",
+            "description": "400 is not of type 'string'"
+        }
+
+        self.assertEqual(expected, input_result.json)
+        self.assertEqual(expected, args_result.json)
+
     def test_post_invalid_content_type_415(self):
         body = "{'input': 'foo'}"
         headers = {"Content-Type": "application/xml"}

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -217,3 +217,16 @@ class NsJailTests(unittest.TestCase):
 
         output = self.nsjail._consume_stdout(nsjail_subprocess)
         self.assertEqual(output, chunk * expected_chunks)
+
+    def test_nsjail_args(self):
+        args = ("foo", "bar")
+        result = self.nsjail.python3("", nsjail_args=args)
+
+        self.assertEqual(result.args[9:11], args)
+
+    def test_py_args(self):
+        args = ("-m", "timeit")
+        result = self.nsjail.python3("", py_args=args)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.args[-3:-1], args)


### PR DESCRIPTION
## Relevant Issues
Closes #105 

## Description
This PR makes it so that you can pass arguments, through an array of strings, that can replace the `"-c"` option. An example of how this would work would be:
```py
>>> import requests
>>> response = requests.post(                                                                                                   
...     "http://localhost:8060/eval",
...     json={"input": "[i for i in range(1000)]", "args": ["-m", "timeit"]}
... )
>>> response.json()
{'stdout': '10000 loops, best of 5: 24.5 usec per loop\n', 'returncode': 0}
```