### PR TITLE
Env deps: add tzdata

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -49,6 +49,7 @@ spec:
                     scipy~=1.5
                     sympy~=1.6
                     toml~=0.10
+                    tzdata~=2021.1
                     yarl~=1.6
       volumes:
         - name: snekbox-user-base-volume


### PR DESCRIPTION
Snekbox is lacking an IANA timezone database, this first-party `tzdata` package will provide them. It can be tested by running the following script:
```py
import zoneinfo
if len(zoneinfo.available_timezones()) == 0:
    print("The environment doesn't have a valid IANA database.")
```