### PR TITLE
Increase available PIDs to 5

### DIFF
--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -9,11 +9,11 @@ time_limit: 6
 
 keep_env: false
 envar: "LANG=en_US.UTF-8"
-envar: "OMP_NUM_THREADS=1"
-envar: "OPENBLAS_NUM_THREADS=1"
-envar: "MKL_NUM_THREADS=1"
-envar: "VECLIB_MAXIMUM_THREADS=1"
-envar: "NUMEXPR_NUM_THREADS=1"
+envar: "OMP_NUM_THREADS=5"
+envar: "OPENBLAS_NUM_THREADS=5"
+envar: "MKL_NUM_THREADS=5"
+envar: "VECLIB_MAXIMUM_THREADS=5"
+envar: "NUMEXPR_NUM_THREADS=5"
 envar: "PYTHONPATH=/snekbox/user_base/lib/python3.9/site-packages"
 envar: "PYTHONIOENCODING=utf-8:strict"
 

--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -107,7 +107,7 @@ mount {
 cgroup_mem_max: 52428800
 cgroup_mem_mount: "/sys/fs/cgroup/memory"
 
-cgroup_pids_max: 1
+cgroup_pids_max: 5
 cgroup_pids_mount: "/sys/fs/cgroup/pids"
 
 iface_no_lo: true

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -50,7 +50,16 @@ class NsJailTests(unittest.TestCase):
     def test_subprocess_resource_unavailable(self):
         code = dedent("""
             import subprocess
-            print(subprocess.check_output('kill -9 6', shell=True).decode())
+
+            # Max PIDs is 5.
+            for _ in range(6):
+                print(subprocess.Popen(
+                    [
+                        '/usr/local/bin/python3',
+                        '-c',
+                        'import time; time.sleep(1)'
+                    ],
+                ).pid)
         """).strip()
 
         result = self.nsjail.python3(code)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -67,6 +67,34 @@ class NsJailTests(unittest.TestCase):
         self.assertIn("Resource temporarily unavailable", result.stdout)
         self.assertEqual(result.stderr, None)
 
+    def test_multiprocess_resource_limits(self):
+        code = dedent("""
+            import time
+            from multiprocessing import Process
+
+            def f():
+                object = "A" * 40_000_000
+                time.sleep(0.5)
+
+
+            proc_1 = Process(target=f)
+            proc_2 = Process(target=f)
+
+            proc_1.start()
+            proc_2.start()
+
+            proc_1.join()
+            proc_2.join()
+
+            print(proc_1.exitcode, proc_2.exitcode)
+        """)
+
+        result = self.nsjail.python3(code)
+
+        exit_codes = result.stdout.strip().split()
+        self.assertIn("-9", exit_codes)
+        self.assertEqual(result.stderr, None)
+
     def test_read_only_file_system(self):
         for path in ("/", "/etc", "/lib", "/lib64", "/snekbox", "/usr"):
             with self.subTest(path=path):


### PR DESCRIPTION
This PR increases the PIDs cgroup limit to 5. Processes spawned in snekbox will have up to 5 PIDs available, each sharing the same memory limits and environment as the parent python process. As far as I could see in testing this does appear safe and processes behave as expected, even when detatching from the parent and so on.

I'd appreciate if anyone with a local setup could give this a shot and play with things like multiprocessing, subprocess and any other low level proc interfaces.