### PR TITLE
Fix passing arguments to python -m snekbox and support Python args

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -85,7 +85,7 @@ pipenv run devsh -c 'echo hello'
 NsJail can be invoked in a more direct manner that does not require using a web server or its API. See `python -m snekbox --help`. Example usage:
 
 ```bash
-python -m snekbox 'print("hello world!")' --time_limit 0
+python -m snekbox 'print("hello world!")' --time_limit 0 --- -m timeit
 ```
 
 With this command, NsJail uses the same configuration normally used through the web API. It also has an alias, `pipenv run eval`.

--- a/snekbox/__main__.py
+++ b/snekbox/__main__.py
@@ -44,5 +44,5 @@ def main() -> None:
         sys.exit(result.returncode)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/snekbox/__main__.py
+++ b/snekbox/__main__.py
@@ -20,7 +20,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     """Evaluate Python code through NsJail."""
     args = parse_args()
-    result = NsJail().python3(args.code, *args.nsjail_args)
+    result = NsJail().python3(args.code, nsjail_args=args.nsjail_args)
     print(result.stdout)
 
 

--- a/snekbox/__main__.py
+++ b/snekbox/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from snekbox.nsjail import NsJail
 
@@ -38,6 +39,9 @@ def main() -> None:
     args = parse_args()
     result = NsJail().python3(args.code, nsjail_args=args.nsjail_args, py_args=args.py_args)
     print(result.stdout)
+
+    if result.returncode != 0:
+        sys.exit(result.returncode)
 
 
 if __name__ == "__main__":

--- a/snekbox/__main__.py
+++ b/snekbox/__main__.py
@@ -5,22 +5,38 @@ from snekbox.nsjail import NsJail
 
 def parse_args() -> argparse.Namespace:
     """Parse the command-line arguments and return the populated namespace."""
-    parser = argparse.ArgumentParser(prog="snekbox", usage="%(prog)s code [nsjail_args ...]")
+    parser = argparse.ArgumentParser(
+        prog="snekbox",
+        usage="%(prog)s [-h] code [nsjail_args ...] [--- py_args ...]",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument("code", help="the Python code to evaluate")
-    parser.add_argument("nsjail_args", nargs="?", help="override configured NsJail options")
+    parser.add_argument(
+        "nsjail_args", nargs="?", default=[], help="override configured NsJail options"
+    )
+    parser.add_argument(
+        "py_args", nargs="?", default=["-c"], help="arguments to pass to the Python process"
+    )
 
-    # nsjail_args is just a dummy for documentation purposes.
-    # Its actual value comes from all the unknown arguments.
+    # nsjail_args and py_args are just dummies for documentation purposes.
+    # Their actual values comes from all the unknown arguments.
     # There doesn't seem to be a better solution with argparse.
     args, unknown = parser.parse_known_args()
-    args.nsjail_args = unknown
+    try:
+        # Can't use double dash because that has special semantics for argparse already.
+        split = unknown.index("---")
+        args.nsjail_args = unknown[:split]
+        args.py_args = unknown[split + 1:]
+    except ValueError:
+        args.nsjail_args = unknown
+
     return args
 
 
 def main() -> None:
     """Evaluate Python code through NsJail."""
     args = parse_args()
-    result = NsJail().python3(args.code, nsjail_args=args.nsjail_args)
+    result = NsJail().python3(args.code, nsjail_args=args.nsjail_args, py_args=args.py_args)
     print(result.stdout)
 
 

--- a/snekbox/__main__.py
+++ b/snekbox/__main__.py
@@ -20,7 +20,7 @@ def parse_args() -> argparse.Namespace:
     )
 
     # nsjail_args and py_args are just dummies for documentation purposes.
-    # Their actual values comes from all the unknown arguments.
+    # Their actual values come from all the unknown arguments.
     # There doesn't seem to be a better solution with argparse.
     args, unknown = parser.parse_known_args()
     try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,51 @@
+import contextlib
+import io
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+import snekbox.__main__ as snekbox_main
+
+
+class ArgParseTests(unittest.TestCase):
+    def test_parse_args(self):
+        subtests = (
+            (
+                ["", "code"],
+                Namespace(code="code", nsjail_args=[], py_args=["-c"])
+            ),
+            (
+                ["", "code", "--time_limit", "0"],
+                Namespace(code="code", nsjail_args=["--time_limit", "0"], py_args=["-c"])
+            ),
+            (
+                ["", "code", "---", "-m", "timeit"],
+                Namespace(code="code", nsjail_args=[], py_args=["-m", "timeit"])
+            ),
+            (
+                ["", "code", "--time_limit", "0", "---", "-m", "timeit"],
+                Namespace(code="code", nsjail_args=["--time_limit", "0"], py_args=["-m", "timeit"])
+            ),
+            (
+                ["", "code", "--time_limit", "0", "---"],
+                Namespace(code="code", nsjail_args=["--time_limit", "0"], py_args=[])
+            ),
+            (
+                ["", "code", "---"],
+                Namespace(code="code", nsjail_args=[], py_args=[])
+            )
+        )
+
+        for argv, expected in subtests:
+            with self.subTest(argv=argv, expected=expected), patch("sys.argv", argv):
+                args = snekbox_main.parse_args()
+                self.assertEqual(args, expected)
+
+    @patch("sys.argv", [""])
+    def test_parse_args_code_missing_exits(self):
+        with self.assertRaises(SystemExit) as cm:
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                snekbox_main.parse_args()
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("the following arguments are required: code", stderr.getvalue())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import unittest
 from argparse import Namespace
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import snekbox.__main__ as snekbox_main
@@ -49,3 +50,51 @@ class ArgParseTests(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 2)
         self.assertIn("the following arguments are required: code", stderr.getvalue())
+
+
+class EntrypointTests(unittest.TestCase):
+    @patch("sys.argv", ["", "code"])
+    @patch("snekbox.__main__.NsJail", autospec=True)
+    def test_main_prints_stdout(self, mock_nsjail):
+        mock_nsjail.return_value.python3.return_value = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="output",
+            stderr=None
+        )
+
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            snekbox_main.main()
+
+        self.assertEqual(stdout.getvalue(), "output\n")
+
+    @patch("sys.argv", ["", "code"])
+    @patch("snekbox.__main__.NsJail", autospec=True)
+    def test_main_exits_with_returncode(self, mock_nsjail):
+        mock_nsjail.return_value.python3.return_value = CompletedProcess(
+            args=[],
+            returncode=137,
+            stdout="output",
+            stderr=None
+        )
+
+        with self.assertRaises(SystemExit) as cm:
+            snekbox_main.main()
+
+        self.assertEqual(cm.exception.code, 137)
+
+    @patch("sys.argv", ["", "code", "--time_limit", "0", "---", "-m", "timeit"])
+    @patch("snekbox.__main__.NsJail", autospec=True)
+    def test_main_forwards_args(self, mock_nsjail):
+        mock_nsjail.return_value.python3.return_value = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="output",
+            stderr=None
+        )
+
+        snekbox_main.main()
+
+        mock_nsjail.return_value.python3.assert_called_once_with(
+            "code", nsjail_args=["--time_limit", "0"], py_args=["-m", "timeit"]
+        )


### PR DESCRIPTION
Fixes #124 

NsJail arguments now properly get forwarded. There's also support for passing Python arguments. This works by separating NsJail and Python args with a  `---`. The approach discussed in the issue, which was to quote all the Python arguments, does not work because argparse treats stuff that starts with a dash as an argument rather than a string.