### PR TITLE
Fix version commit count

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ jobs:
           set -eu
           version=$(python scripts/version.py)
           echo "::set-output name=version::version"
+          printf "%s\n" "${version}"
 
       # The current version (v2) of Docker's build-push action uses buildx,
       # which comes with BuildKit. It has cache features which can speed up

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # The version script relies on history. Fetch 100 commits to be safe.
+          fetch-depth: 100
 
       - name: Get version
         id: version

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,9 +36,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
-      # The Dockerfile will be needed.
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # The version script relies on history. Fetch 100 commits to be safe.
+          fetch-depth: 100
 
       # Build the final production image and push it to GHCR.
       # Tag it with both the short commit SHA and 'latest'.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ All environment variables have defaults and are therefore not required to be set
 Name | Description
 ---- | -----------
 `DEBUG` | Enable debug logging if set to a non-empty value.
-`GIT_SHA` | [Sentry release] identifier. Set in CI.
 `NSJAIL_CFG` | Path to the NsJail configuration file.
 `NSJAIL_PATH` | Path to the NsJail binary.
 `SNEKBOX_SENTRY_DSN` | [Data Source Name] for Sentry. Sentry is disabled if left unset.

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -31,7 +31,8 @@ def count_commits_on_date(dt: datetime.datetime) -> int:
     args = ["git", "log", "--oneline", "--after", str(dt.timestamp())]
     stdout = subprocess.check_output(args, text=True)
 
-    return stdout.strip().count("\n")
+    # The last newline is stripped, so it has to be manually counted with + 1.
+    return stdout.strip().count("\n") + 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The commit count was off by 1 since the last newline was being stripped and thus not counted. In CI, the checkout action was not retrieving history, so the commit count was not able to get the right number of commits. I set it to fetch 100 commits, which should be more than reasonably safe; it would take over 100 commits on the release day to cause the version to be incorrect, and even then it's only really a problem if a second release happens on the same day.