### PR TITLE
Import the WSGI app via the config during tests

### DIFF
--- a/snekbox/utils/logging.py
+++ b/snekbox/utils/logging.py
@@ -1,6 +1,10 @@
 import logging
 import os
 import sys
+import warnings
+
+from falcon.util.deprecation import DeprecatedWarning
+
 
 __all__ = ("FORMAT", "init_logger", "init_sentry")
 
@@ -21,11 +25,14 @@ def init_logger(debug: bool) -> None:
 
 def init_sentry(version: str) -> None:
     """Initialise the Sentry SDK if it's installed."""
-    try:
-        import sentry_sdk
-        from sentry_sdk.integrations.falcon import FalconIntegration
-    except ImportError:
-        return
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=r".*\bapi_helpers\b", category=DeprecatedWarning)
+
+        try:
+            import sentry_sdk
+            from sentry_sdk.integrations.falcon import FalconIntegration
+        except ImportError:
+            return
 
     sentry_sdk.init(
         dsn=os.environ.get("SNEKBOX_SENTRY_DSN", ""),


### PR DESCRIPTION
Relying more on Gunicorn and its config parsing will avoid discrepancies between the test and production environments. This is in response to me forgetting to call the app class in the config, but remembering to do so in the test (26c729a4d99e3f65f000030e251a4678241c599b).

Also ignore a deprecation warning from Sentry SDK's Falcon integration.