### PR TITLE
Make the output size limit customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All environment variables have defaults and are therefore not required to be set
 
 Name | Description
 ---- | -----------
-`DEBUG` | Enable debug logging if set to a non-empty value.
+`SNEKBOX_DEBUG` | Enable debug logging if set to a non-empty value.
 `SNEKBOX_SENTRY_DSN` | [Data Source Name] for Sentry. Sentry is disabled if left unset.
 
 ## Third-party Packages

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ NsJail is configured through [`snekbox.cfg`]. It contains the exact values for t
 
 ### Gunicorn
 
-[Gunicorn settings] can be found in [`gunicorn.conf.py`]. In the default configuration, the worker count and the bind address are likely the only things of any interest. Since it uses the default synchronous workers, the [worker count] effectively determines how many concurrent code evaluations can be performed.
+[Gunicorn settings] can be found in [`gunicorn.conf.py`]. In the default configuration, the worker count, the bind address, and the WSGI app URI are likely the only things of any interest. Since it uses the default synchronous workers, the [worker count] effectively determines how many concurrent code evaluations can be performed.
+
+`wsgi_app` can be given arguments which are forwarded to the `NsJail` object. For example, `wsgi_app = "snekbox:SnekAPI(max_output_size=2_000_000, read_chunk_size=20_000)"`.
 
 ### Environment Variables
 
@@ -125,3 +127,4 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 [sentry release]: https://docs.sentry.io/platforms/python/configuration/releases/
 [data source name]: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
 [GitHub Container Registry]: https://github.com/orgs/python-discord/packages/container/package/snekbox
+[`NsJail`]: snekbox/nsjail.py

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Snekbox -->>- Client: JSON response
 
 The code is executed in a Python process that is launched through [NsJail], which is responsible for sandboxing the Python process.
 
-The output returned by snekbox is truncated at around 1 MB.
+The output returned by snekbox is truncated at around 1 MB by default, but this can be [configured](#gunicorn).
 
 ## HTTP REST API
 
@@ -68,7 +68,7 @@ NsJail is configured through [`snekbox.cfg`]. It contains the exact values for t
 
 [Gunicorn settings] can be found in [`gunicorn.conf.py`]. In the default configuration, the worker count, the bind address, and the WSGI app URI are likely the only things of any interest. Since it uses the default synchronous workers, the [worker count] effectively determines how many concurrent code evaluations can be performed.
 
-`wsgi_app` can be given arguments which are forwarded to the `NsJail` object. For example, `wsgi_app = "snekbox:SnekAPI(max_output_size=2_000_000, read_chunk_size=20_000)"`.
+`wsgi_app` can be given arguments which are forwarded to the [`NsJail`] object. For example, `wsgi_app = "snekbox:SnekAPI(max_output_size=2_000_000, read_chunk_size=20_000)"`.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,7 @@ All environment variables have defaults and are therefore not required to be set
 Name | Description
 ---- | -----------
 `DEBUG` | Enable debug logging if set to a non-empty value.
-`NSJAIL_CFG` | Path to the NsJail configuration file.
-`NSJAIL_PATH` | Path to the NsJail binary.
 `SNEKBOX_SENTRY_DSN` | [Data Source Name] for Sentry. Sentry is disabled if left unset.
-
-Note: relative paths are relative to the root of the repository.
 
 ## Third-party Packages
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ipc: none
     tty: true
     environment:
-      DEBUG: 1
+      SNEKBOX_DEBUG: 1
       PYTHONDONTWRITEBYTECODE: 1
     build:
       context: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ relative_files = true
 [tool.black]
 line-length = 100
 target-version = ["py310"]
-force-exclude = ["snekbox/config_pb2.py"]
+force-exclude = "snekbox/config_pb2.py"
 
 [tool.isort]
 line_length = 100

--- a/snekbox/__init__.py
+++ b/snekbox/__init__.py
@@ -1,7 +1,7 @@
 import os
 from importlib import metadata
 
-DEBUG = os.environ.get("DEBUG", False)
+DEBUG = os.environ.get("SNEKBOX_DEBUG", False)
 
 try:
     __version__ = metadata.version("snekbox")

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -29,8 +29,8 @@ class EvalResource:
         "required": ["input"],
     }
 
-    def __init__(self):
-        self.nsjail = NsJail()
+    def __init__(self, nsjail: NsJail):
+        self.nsjail = nsjail
 
     @validate(REQ_SCHEMA)
     def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:

--- a/snekbox/api/snekapi.py
+++ b/snekbox/api/snekapi.py
@@ -1,11 +1,15 @@
 import falcon
 
+from snekbox.nsjail import NsJail
+
 from .resources import EvalResource
 
 
 class SnekAPI(falcon.App):
     """
     The main entry point to the snekbox JSON API.
+
+    Forward arguments to a new `NsJail` object.
 
     Routes:
 
@@ -21,6 +25,7 @@ class SnekAPI(falcon.App):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__()
 
-        self.add_route("/eval", EvalResource())
+        nsjail = NsJail(*args, **kwargs)
+        self.add_route("/eval", EvalResource(nsjail))

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 LOG_PATTERN = re.compile(
     r"\[(?P<level>(I)|[DWEF])\]\[.+?\](?(2)|(?P<func>\[\d+\] .+?:\d+ )) ?(?P<msg>.+)"
 )
-LOG_BLACKLIST = ("Process will be ",)
 
 NSJAIL_PATH = os.getenv("NSJAIL_PATH", "/usr/sbin/nsjail")
 NSJAIL_CFG = os.getenv("NSJAIL_CFG", "./config/snekbox.cfg")
@@ -79,10 +78,6 @@ class NsJail:
                 continue
 
             msg = match["msg"]
-            if not DEBUG and any(msg.startswith(s) for s in LOG_BLACKLIST):
-                # Skip blacklisted messages if not debugging.
-                continue
-
             if DEBUG and match["func"]:
                 # Prepend PID, function signature, and line number if debugging.
                 msg = f"{match['func']}{msg}"

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 import subprocess
 import sys
@@ -22,9 +21,6 @@ LOG_PATTERN = re.compile(
     r"\[(?P<level>(I)|[DWEF])\]\[.+?\](?(2)|(?P<func>\[\d+\] .+?:\d+ )) ?(?P<msg>.+)"
 )
 
-NSJAIL_PATH = os.getenv("NSJAIL_PATH", "/usr/sbin/nsjail")
-NSJAIL_CFG = os.getenv("NSJAIL_CFG", "./config/snekbox.cfg")
-
 
 class NsJail:
     """
@@ -35,8 +31,8 @@ class NsJail:
 
     def __init__(
         self,
-        nsjail_path: str = NSJAIL_PATH,
-        config_path: str = NSJAIL_CFG,
+        nsjail_path: str = "/usr/sbin/nsjail",
+        config_path: str = "./config/snekbox.cfg",
         max_output_size: int = 1_000_000,
         read_chunk_size: int = 10_000,
     ):

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -11,7 +11,7 @@ class SnekAPITestCase(testing.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.patcher = mock.patch("snekbox.api.resources.eval.NsJail", autospec=True)
+        self.patcher = mock.patch("snekbox.api.snekapi.NsJail", autospec=True)
         self.mock_nsjail = self.patcher.start()
         self.mock_nsjail.return_value.python3.return_value = CompletedProcess(
             args=[], returncode=0, stdout="output", stderr="error"

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -285,18 +285,17 @@ class NsJailTests(unittest.TestCase):
 
 
 class NsJailArgsTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._temp_dir = tempfile.TemporaryDirectory()
-        cls.addClassCleanup(cls._temp_dir.cleanup)
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.addClassCleanup(self._temp_dir.cleanup)
 
-        cls.nsjail_path = shutil.copy2("/usr/sbin/nsjail", cls._temp_dir.name)
-        cls.config_path = shutil.copy2("./config/snekbox.cfg", cls._temp_dir.name)
-        cls.max_output_size = 1_234_567
-        cls.read_chunk_size = 12_345
+        self.nsjail_path = shutil.copy2("/usr/sbin/nsjail", self._temp_dir.name)
+        self.config_path = shutil.copy2("./config/snekbox.cfg", self._temp_dir.name)
+        self.max_output_size = 1_234_567
+        self.read_chunk_size = 12_345
 
-        cls.nsjail = NsJail(
-            cls.nsjail_path, cls.config_path, cls.max_output_size, cls.read_chunk_size
+        self.nsjail = NsJail(
+            self.nsjail_path, self.config_path, self.max_output_size, self.read_chunk_size
         )
 
         logging.getLogger("snekbox.nsjail").setLevel(logging.WARNING)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -5,7 +5,7 @@ import unittest
 import unittest.mock
 from textwrap import dedent
 
-from snekbox.nsjail import OUTPUT_MAX, READ_CHUNK_SIZE, NsJail
+from snekbox.nsjail import NsJail
 
 
 class NsJailTests(unittest.TestCase):
@@ -255,8 +255,8 @@ class NsJailTests(unittest.TestCase):
         self.assertEqual(result.returncode, 143)
 
     def test_large_output_is_truncated(self):
-        chunk = "a" * READ_CHUNK_SIZE
-        expected_chunks = OUTPUT_MAX // sys.getsizeof(chunk) + 1
+        chunk = "a" * self.nsjail.read_chunk_size
+        expected_chunks = self.nsjail.max_output_size // sys.getsizeof(chunk) + 1
 
         nsjail_subprocess = unittest.mock.MagicMock()
 

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -1,6 +1,8 @@
 import io
 import logging
+import shutil
 import sys
+import tempfile
 import unittest
 import unittest.mock
 from textwrap import dedent
@@ -280,3 +282,38 @@ class NsJailTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.args[-3:-1], args)
+
+
+class NsJailArgsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._temp_dir = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls._temp_dir.cleanup)
+
+        cls.nsjail_path = shutil.copy2("/usr/sbin/nsjail", cls._temp_dir.name)
+        cls.config_path = shutil.copy2("./config/snekbox.cfg", cls._temp_dir.name)
+        cls.max_output_size = 1_234_567
+        cls.read_chunk_size = 12_345
+
+        cls.nsjail = NsJail(
+            cls.nsjail_path, cls.config_path, cls.max_output_size, cls.read_chunk_size
+        )
+
+        logging.getLogger("snekbox.nsjail").setLevel(logging.WARNING)
+
+    def test_nsjail_path(self):
+        result = self.nsjail.python3("")
+
+        self.assertEqual(result.args[0], self.nsjail_path)
+
+    def test_config_path(self):
+        result = self.nsjail.python3("")
+
+        i = result.args.index("--config") + 1
+        self.assertEqual(result.args[i], self.config_path)
+
+    def test_init_args(self):
+        self.assertEqual(self.nsjail.nsjail_path, self.nsjail_path)
+        self.assertEqual(self.nsjail.config_path, self.config_path)
+        self.assertEqual(self.nsjail.max_output_size, self.max_output_size)
+        self.assertEqual(self.nsjail.read_chunk_size, self.read_chunk_size)


### PR DESCRIPTION
Resolves #104 

The `NsJail` object can now take more arguments. These can be specified by modifying the WSGI app URI in the Gunicorn config. See the updated README.md for more info.

Also refactored some minor things and fixed a mistake in black's config.