### PR TITLE
add typing-extensions to snekbox

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -49,6 +49,7 @@ spec:
                     pyyaml~=5.3
                     sympy~=1.6
                     toml~=0.10
+                    typing-extensions~=4.2
                     tzdata~=2021.1
                     yarl~=1.7
       volumes:


### PR DESCRIPTION
What the title says. I hope I did this right.

The version should exist, since that's what's at the top of https://pypi.org/project/typing-extensions/.