### PR TITLE
Create v1 cgroups as needed

### DIFF
--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -336,8 +336,8 @@ class NsJailCgroupTests(unittest.TestCase):
                 rw: false
             }
             exec_bin {
-                path: "/usr/local/bin/python"
-                arg: "-Squ"
+                path: "/bin/su"
+                arg: ""
             }
             """
         ).strip()
@@ -383,4 +383,4 @@ class NsJailCgroupTests(unittest.TestCase):
 
                         result = nsjail.python3("")
 
-                        self.assertEqual(result.returncode, 0)
+                        self.assertNotEqual(result.returncode, 255)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -5,6 +5,8 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
+from itertools import product
+from pathlib import Path
 from textwrap import dedent
 
 from snekbox.nsjail import NsJail
@@ -316,3 +318,69 @@ class NsJailArgsTests(unittest.TestCase):
         self.assertEqual(self.nsjail.config_path, self.config_path)
         self.assertEqual(self.nsjail.max_output_size, self.max_output_size)
         self.assertEqual(self.nsjail.read_chunk_size, self.read_chunk_size)
+
+
+class NsJailCgroupTests(unittest.TestCase):
+    # This should still pass for v2, even if this test isn't relevant.
+    def test_cgroupv1(self):
+        logging.getLogger("snekbox.nsjail").setLevel(logging.ERROR)
+        logging.getLogger("snekbox.utils.swap").setLevel(logging.ERROR)
+
+        config_base = dedent(
+            """
+            mode: ONCE
+            mount {
+                src: "/"
+                dst: "/"
+                is_bind: true
+                rw: false
+            }
+            exec_bin {
+                path: "/usr/local/bin/python"
+                arg: "-Squ"
+            }
+            """
+        ).strip()
+
+        cases = (
+            (
+                (
+                    "cgroup_mem_max: 52428800",
+                    # memory.limit_in_bytes must be set before memory.memsw.limit_in_bytes
+                    "cgroup_mem_max: 52428800\ncgroup_mem_memsw_max: 104857600",
+                    "cgroup_mem_max: 52428800\ncgroup_mem_swap_max: 52428800",
+                ),
+                "cgroup_mem_mount: '/sys/fs/cgroup/memory'",
+                "cgroup_mem_parent: 'NSJAILTEST1'",
+            ),
+            (
+                ("cgroup_pids_max: 20",),
+                "cgroup_pids_mount: '/sys/fs/cgroup/pids'",
+                "cgroup_pids_parent: 'NSJAILTEST2'",
+            ),
+            (
+                ("cgroup_net_cls_classid: 1048577",),
+                "cgroup_net_cls_mount: '/sys/fs/cgroup/net_cls'",
+                "cgroup_net_cls_parent: 'NSJAILTEST3'",
+            ),
+            (
+                ("cgroup_cpu_ms_per_sec: 800",),
+                "cgroup_cpu_mount: '/sys/fs/cgroup/cpu'",
+                "cgroup_cpu_parent: 'NSJAILTEST4'",
+            ),
+        )
+
+        # protobuf doesn't parse correctly when NamedTemporaryFile is used directly.
+        with tempfile.TemporaryDirectory() as directory:
+            for values, mount, parent in cases:
+                for lines in product(values, (mount, ""), (parent, "")):
+                    with self.subTest(config=lines):
+                        config_path = str(Path(directory, "config.cfg"))
+                        with open(config_path, "w", encoding="utf8") as f:
+                            f.write("\n".join(lines + (config_base,)))
+
+                        nsjail = NsJail(config_path=config_path)
+
+                        result = nsjail.python3("")
+
+                        self.assertEqual(result.returncode, 0)


### PR DESCRIPTION
Resolves #101

NsJail puts subprocess cgroups under parent cgroups. However, it does not create the parents automatically. Thus, snekbox has to do this. Previously, for v1, only the `memory` and `pids` cgroup parents were being created. Now, all four controllers supported by NsJail are also supported by snekbox.

It looks at the NsJail config to determine if a cgroup parent needs to be created. Basically, if a value is non-default, then NsJail will create a cgroup and thus will rely on a parent existing.

For the test, I test each controller separately. Each controller has several test cases for the various combinations of config values (default vs explicit). However, I don't think the mount value actually has any effect since it's equivalent to the default. I can't use a non-default value because I don't think it's easy to change where the cgroup fs is mounted if it's already mounted.