### PR TITLE
stop using the deprecated set-output command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -eu
           version=$(python scripts/version.py)
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
           printf "%s\n" "${version}"
 
       # The current version (v2) of Docker's build-push action uses buildx,
@@ -63,8 +63,8 @@ jobs:
             cache_from="type=gha,scope=buildkit-${GITHUB_REF}"
             cache_to="${cache_from},mode=max"
           fi
-          echo "::set-output name=cache_from::${cache_from:-}"
-          echo "::set-output name=cache_to::${cache_to:-}"
+          echo "cache_from=${cache_from:-}" >> $GITHUB_OUTPUT
+          echo "cache_to=${cache_to:-}" >> $GITHUB_OUTPUT
 
       # Build the "DEV" version of the image, which targets the `venv` stage
       # and includes development dependencies.

--- a/.github/workflows/sentry_release.yaml
+++ b/.github/workflows/sentry_release.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           set -eu
           version=$(python scripts/version.py)
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
           printf "%s\n" "${version}"
 
       - name: Create a Sentry.io release


### PR DESCRIPTION
Looking at the [last action run](https://github.com/python-discord/snekbox/actions/runs/3399634090), there were over 50 warnings from github about using deprecated actions and warnings
This solves the simplest of them by replacing all of the `::set-output` commands with the new syntax.

See [the changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for more information.