### PR TITLE
Add einspect

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -36,6 +36,7 @@ spec:
                     arrow~=1.2
                     attrs~=22.1
                     beautifulsoup4~=4.11
+                    einspect~=0.4
                     fishhook~=0.2
                     forbiddenfruit~=0.1
                     fuzzywuzzy~=0.18


### PR DESCRIPTION
This proposes to add <https://pypi.org/project/einspect/> to our deployment venv.

I think it would be quite useful in discussions in #internals-and-peps as well as showing implementation details of python object structure to beginners who are curious.
```python
from einspect import view

a = [*range(18)]
print(view(a).allocated)  # 18

b = list(i for i in range(18))
print(view(b).allocated)  # 24
```
For example many have asked how python ints are actually implemented with base-30 arrays:
```python
from einspect import view

a = 2**30 + 150
print(view(a).info())
```
```python
PyLongObject (at 0x105108090):
   ob_refcnt: Py_ssize_t = 4
   ob_type: *PyTypeObject = &[int]
   ob_size: Py_ssize_t = 2
   ob_digit: Array[c_uint32] = [150, 1]
```

The package is in pure python with 1 dependency - `typing-extensions`
Compatibility is tested from 3.8 - 3.11
License is MIT