### PR TITLE
Add `--upgrade` flag to deployment pip install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -9,19 +9,19 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: &flake8_version 5.0.4
+    rev: &flake8_version 6.0.0
     hooks:
       - &flake8_hook
         id: flake8

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -31,7 +31,7 @@ spec:
                   - "-c"
                   - >-
                     PYTHONUSERBASE=/snekbox/user_base
-                    pip install --user
+                    pip install --user --upgrade
                     anyio[trio]~=3.6
                     arrow~=1.2
                     attrs~=22.1

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                     pip install --user --upgrade
                     anyio[trio]~=3.6
                     arrow~=1.2
-                    attrs~=22.1
+                    attrs~=22.2
                     beautifulsoup4~=4.11
                     einspect~=0.5
                     fishhook~=0.2
@@ -43,17 +43,17 @@ spec:
                     lark~=1.1
                     matplotlib~=3.6
                     more-itertools~=9.0
-                    networkx~=2.8
-                    numpy~=1.23
+                    networkx~=3.0
+                    numpy~=1.24
                     pandas~=1.5
                     pendulum~=2.1
                     python-dateutil~=2.8
                     pyyaml~=6.0
-                    scipy~=1.9.2
+                    scipy~=1.10
                     sympy~=1.11
                     toml~=0.10
                     typing-extensions~=4.4
-                    tzdata~=2022.6
+                    tzdata~=2022.7
                     yarl~=1.8
       volumes:
         - name: snekbox-user-base-volume


### PR DESCRIPTION
Since pip install doesn't actually update patch versions with `~=` version specifiers, we may not be getting the newest security / patch releases for our deployment venv.

This adds the `--upgrade` flag

Update:
- due to broken isort, also bumped hooks in `pre-commit-config.yaml`