### PR TITLE
Exclude hidden paths in files output

### DIFF
--- a/snekbox/memfs.py
+++ b/snekbox/memfs.py
@@ -138,6 +138,11 @@ class MemFS:
         """
         count = 0
         for file in self.output.rglob(pattern):
+            # Ignore hidden directories or files
+            if any(part.startswith(".") for part in file.parts):
+                log.info(f"Skipping hidden path {file!s}")
+                continue
+
             if exclude_files and (orig_time := exclude_files.get(file)):
                 new_time = file.stat().st_mtime
                 log.info(f"Checking {file.name} ({orig_time=}, {new_time=})")

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -170,6 +170,25 @@ class NsJailTests(unittest.TestCase):
         self.assertIn("No space left on device", result.stdout)
         self.assertEqual(result.stderr, None)
 
+    def test_write_hidden_exclude(self):
+        """Hidden paths should be excluded from output."""
+        code = dedent(
+            """
+            from pathlib import Path
+
+            Path("normal").mkdir()
+            Path("normal/a.txt").write_text("a")
+            Path("normal/.hidden.txt").write_text("a")
+            Path(".hidden").mkdir()
+            Path(".hidden/b.txt").write_text("b")
+            """
+        ).strip()
+
+        result = self.eval_file(code)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(result.files), 1)
+        self.assertEqual(result.files[0].content, b"a")
+
     def test_forkbomb_resource_unavailable(self):
         code = dedent(
             """


### PR DESCRIPTION
To avoid cluttering files output with cache and configs from libraries like matplotlib, this will exclude parsing output files with a hidden (leading ".") directory or file name.