### PR TITLE
Disable dependencies without wheels on 3.12

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -42,12 +42,13 @@ spec:
                     forbiddenfruit~=0.1
                     fuzzywuzzy~=0.18
                     lark~=1.1
-                    matplotlib~=3.6
+                    "matplotlib~=3.6 ; python_version == \'3.11\'"
                     more-itertools~=9.0
                     networkx~=3.0
-                    numpy~=1.24
-                    pandas~=1.5
-                    pendulum~=2.1
+                    "numpy~=1.24 ; python_version == \'3.11\'"
+                    "numpy==1.26.0b1 ; python_version == \'3.12\'"
+                    "pandas~=1.5 ; python_version == \'3.11\'"
+                    "pendulum~=2.1 ; python_version == \'3.11\'"
                     python-dateutil~=2.8
                     pyyaml~=6.0
                     scipy~=1.10
@@ -55,7 +56,7 @@ spec:
                     toml~=0.10
                     typing-extensions~=4.4
                     tzdata~=2022.7
-                    yarl~=1.8
+                    "yarl~=1.8 ; python_version == \'3.11\'"
                     ' \;
       volumes:
         - name: snekbox-user-base-volume


### PR DESCRIPTION
Disables dependencies which do not install in 3.12rc1 as they require build tools. We also use a numpy release candidate to maintain numpy and scipy support in 3.12rc1.

All dependencies have been tested to install correctly on 3.12rc1 within the snekbox container.