### PR TITLE
Refactor how we process eval dependencies

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -12,6 +12,22 @@ spec:
       labels:
         app: snekbox
     spec:
+      initContainers:
+        - name: deps-install
+          image: ghcr.io/python-discord/snekbox:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: snekbox-user-base-volume
+              mountPath: /snekbox/user_base
+          env:
+            - name: PYTHONUSERBASE
+              value: /snekbox/user_base
+          command:
+            - "/bin/sh"
+            - "-c"
+            - >-
+              find /lang/python -mindepth 1 -maxdepth 1 -type d -exec
+              {}/bin/python -m pip install --user -U -r requirements/eval-deps.pip \;
       containers:
         - name: snekbox
           image: ghcr.io/python-discord/snekbox:latest
@@ -23,41 +39,6 @@ spec:
           volumeMounts:
             - name: snekbox-user-base-volume
               mountPath: /snekbox/user_base
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - "/bin/sh"
-                  - "-c"
-                  - >-
-                    find /lang/python -mindepth 1 -maxdepth 1 -type d -exec
-                    sh -c 'PYTHONUSERBASE=/snekbox/user_base &&
-                    {}/bin/python -m pip install --user -U
-                    anyio[trio]~=3.6
-                    arrow~=1.2
-                    attrs~=22.2
-                    beautifulsoup4~=4.11
-                    einspect~=0.5
-                    fishhook~=0.2
-                    forbiddenfruit~=0.1
-                    fuzzywuzzy~=0.18
-                    lark~=1.1
-                    "matplotlib~=3.6 ; python_version == \'3.11\'"
-                    more-itertools~=9.0
-                    networkx~=3.0
-                    "numpy~=1.24 ; python_version == \'3.11\'"
-                    "numpy==1.26.0b1 ; python_version == \'3.12\'"
-                    "pandas~=1.5 ; python_version == \'3.11\'"
-                    "pendulum~=2.1 ; python_version == \'3.11\'"
-                    python-dateutil~=2.8
-                    pyyaml~=6.0
-                    scipy~=1.10
-                    sympy~=1.11
-                    toml~=0.10
-                    typing-extensions~=4.4
-                    tzdata~=2022.7
-                    "yarl~=1.8 ; python_version == \'3.11\'"
-                    ' \;
       volumes:
         - name: snekbox-user-base-volume
           hostPath:

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -1,0 +1,24 @@
+anyio[trio]~=3.6
+arrow~=1.2
+attrs~=22.2
+beautifulsoup4~=4.11
+einspect~=0.5
+fishhook~=0.2
+forbiddenfruit~=0.1
+fuzzywuzzy~=0.18
+lark~=1.1
+matplotlib~=3.6 ; python_version == '3.11'
+more-itertools~=9.0
+networkx~=3.0
+numpy~=1.24 ; python_version == '3.11'
+numpy==1.26.0b1 ; python_version == '3.12'
+pandas~=1.5 ; python_version == '3.11'
+pendulum~=2.1 ; python_version == '3.11'
+python-dateutil~=2.8
+pyyaml~=6.0
+scipy~=1.10
+sympy~=1.11
+toml~=0.10
+typing-extensions~=4.4
+tzdata~=2022.7
+yarl~=1.8 ; python_version == '3.11'


### PR DESCRIPTION
Right now, our eval dependencies are pulled in using a script embedded within the deployment file, and all dependencies are listed there. This gets a bit messy the more dependencies we want to add, especially if we want to add version markers.

This PR splits out the dependencies into a new file under `requirements/` and moves the dependency install process to it's own init container instead of being a task that executes within the snekbox container after it starts. This also allows for greater observability into the dependencies pull process as logs can be fetched from init containers with `kubectl logs deploy/snekbox -c deps-install`.