### PR TITLE
Bump Python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,13 @@ COPY --link scripts/build_python.sh /
 
 # ------------------------------------------------------------------------------
 FROM builder-py-base as builder-py-3_11
-RUN git clone -b v2.3.24 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && /build_python.sh 3.11.4
+RUN git clone -b v2.3.26 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && /build_python.sh 3.11.5
 
 # ------------------------------------------------------------------------------
 FROM builder-py-base as builder-py-3_12
-RUN git clone -b v2.3.24 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && /build_python.sh 3.12.0rc1
+RUN git clone -b v2.3.26 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && /build_python.sh 3.12.0rc2
 
 # ------------------------------------------------------------------------------
 FROM python:3.11-slim-buster as base

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -11,7 +11,7 @@ matplotlib~=3.7 ; python_version == '3.11'  # https://github.com/matplotlib/matp
 more-itertools~=10.1
 networkx~=3.1
 numpy~=1.25 ; python_version == '3.11'
-numpy==1.26.0b1 ; python_version == '3.12'
+numpy==1.26.0rc1 ; python_version == '3.12'
 pandas~=2.0 ; python_version == '3.11'
 pendulum~=2.1 ; python_version == '3.11'  # https://github.com/sdispater/pendulum/issues/696
 python-dateutil~=2.8


### PR DESCRIPTION
3.11.5 requires at least pyenv 2.3.25, so bumped to latest (2.3.26) for good measure anyway.

3.12.0rc2 requires pyenv 2.3.25