### PR TITLE
Update to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM buildpack-deps:buster as builder-nsjail
+FROM buildpack-deps:bookworm as builder-nsjail
 
 WORKDIR /nsjail
 
@@ -17,7 +17,7 @@ RUN git clone -b master --single-branch https://github.com/google/nsjail.git . \
 RUN make
 
 # ------------------------------------------------------------------------------
-FROM buildpack-deps:buster as builder-py-base
+FROM buildpack-deps:bookworm as builder-py-base
 
 ENV PYENV_ROOT=/pyenv \
     PYTHON_CONFIGURE_OPTS='--disable-test-modules --enable-optimizations \
@@ -42,7 +42,7 @@ RUN git clone -b v2.3.26 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROO
     && /build_python.sh 3.12.0rc2
 
 # ------------------------------------------------------------------------------
-FROM python:3.11-slim-buster as base
+FROM python:3.11-slim-bookworm as base
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=false
@@ -52,7 +52,7 @@ RUN apt-get -y update \
         gcc \
         git \
         libnl-route-3-200 \
-        libprotobuf17 \
+        libprotobuf32 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --link --from=builder-nsjail /nsjail/nsjail /usr/sbin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
      - "8060:8060"
     init: true
-    ipc: none
+    ipc: private
     tty: true
     environment:
       SNEKBOX_DEBUG: 1

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Generator
+from contextlib import nullcontext
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Iterable, TypeVar
@@ -56,7 +57,7 @@ class NsJail:
         memfs_home: str = "home",
         memfs_output: str = "home",
         files_limit: int | None = 100,
-        files_timeout: int | None = 5,
+        files_timeout: float | None = 5,
         files_pattern: str = "**/[!_]*",
     ):
         """
@@ -267,7 +268,7 @@ class NsJail:
 
             # Parse attachments with time limit
             try:
-                with time_limit(self.files_timeout):
+                with time_limit(self.files_timeout) if self.files_timeout else nullcontext():
                     attachments = fs.files_list(
                         limit=self.files_limit,
                         pattern=self.files_pattern,

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -233,7 +233,7 @@ class NsJailTests(unittest.TestCase):
             size = 32 * 1024 * 1024
 
             with open("file", "w") as f:
-                for _ in range((size // 1024) - 5):
+                for _ in range(size // 1024):
                     f.write(data)
 
             for i in range(100):
@@ -242,7 +242,7 @@ class NsJailTests(unittest.TestCase):
         ).strip()
         # A value higher than the actual memory needed is used to avoid the limit
         # on total file size being reached before the timeout when reading.
-        nsjail = NsJail(memfs_instance_size=512 * Size.MiB, files_timeout=1)
+        nsjail = NsJail(memfs_instance_size=128 * Size.MiB, files_timeout=0.1)
         result = nsjail.python3(["-c", code])
         self.assertEqual(result.returncode, None)
         self.assertEqual(


### PR DESCRIPTION
Mount /dev/shm in the container by setting ipc to "private". This is the same as "none" (the previous value) with the only difference being that shm is mounted. This is needed for integration tests to pass.

The integration tests always relied on shared memory due to their use of multiprocessing. They managed to work because glibc used to fall back to /tmp if /dev/shm wasn't available. However, newer versions of glibc, which Debian Bookworm now uses, removed that fallback behaviour.