### PR TITLE
Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY --link --from=builder-py-3_11 /lang/ /lang/
 COPY --link --from=builder-py-3_12 /lang/ /lang/
 
 RUN chmod +x /usr/sbin/nsjail \
-    && ln -s /lang/python/3.11/ /lang/python/default
+    && ln -s /lang/python/3.12/ /lang/python/default
 
 # ------------------------------------------------------------------------------
 FROM base as venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,13 @@ RUN apt-get -y update \
 COPY --link scripts/build_python.sh /
 
 # ------------------------------------------------------------------------------
-FROM builder-py-base as builder-py-3_11
-RUN git clone -b v2.3.26 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && /build_python.sh 3.11.5
-
-# ------------------------------------------------------------------------------
 FROM builder-py-base as builder-py-3_12
 RUN git clone -b v2.3.28 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
     && /build_python.sh 3.12.0
-
+# ------------------------------------------------------------------------------
+FROM builder-py-base as builder-py-3_13
+RUN git clone -b v2.3.28 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && /build_python.sh 3.13-dev
 # ------------------------------------------------------------------------------
 FROM python:3.11-slim-bookworm as base
 
@@ -56,8 +54,8 @@ RUN apt-get -y update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --link --from=builder-nsjail /nsjail/nsjail /usr/sbin/
-COPY --link --from=builder-py-3_11 /lang/ /lang/
 COPY --link --from=builder-py-3_12 /lang/ /lang/
+COPY --link --from=builder-py-3_13 /lang/ /lang/
 
 RUN chmod +x /usr/sbin/nsjail \
     && ln -s /lang/python/3.12/ /lang/python/default

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN git clone -b v2.3.26 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROO
 
 # ------------------------------------------------------------------------------
 FROM builder-py-base as builder-py-3_12
-RUN git clone -b v2.3.26 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && /build_python.sh 3.12.0rc2
+RUN git clone -b v2.3.28 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && /build_python.sh 3.12.0
 
 # ------------------------------------------------------------------------------
 FROM python:3.11-slim-bookworm as base

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -1,5 +1,5 @@
-anyio[trio]~=3.7
-arrow~=1.2
+anyio[trio]~=4.0
+arrow~=1.3
 attrs~=23.1
 beautifulsoup4~=4.12
 einspect~=0.5 ; python_version == '3.12'
@@ -18,6 +18,6 @@ pyyaml~=6.0
 scipy~=1.11 ; python_version == '3.12'
 sympy~=1.12
 toml~=0.10
-typing-extensions~=4.7
+typing-extensions~=4.8
 tzdata~=2023.3
 #yarl~=1.9 # Doesn't support 3.12, see https://github.com/aio-libs/yarl/issues/894

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -17,7 +17,6 @@ python-dateutil~=2.8
 pyyaml~=6.0
 scipy~=1.11 ; python_version == '3.12'
 sympy~=1.12
-toml~=0.10
 typing-extensions~=4.8
 tzdata~=2023.3
 #yarl~=1.9 # Doesn't support 3.12, see https://github.com/aio-libs/yarl/issues/894

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -2,23 +2,22 @@ anyio[trio]~=3.7
 arrow~=1.2
 attrs~=23.1
 beautifulsoup4~=4.12
-einspect~=0.5
+einspect~=0.5 ; python_version == '3.12'
 fishhook~=0.2
 forbiddenfruit~=0.1
 fuzzywuzzy~=0.18
 lark~=1.1
-matplotlib~=3.7 ; python_version == '3.11'  # https://github.com/matplotlib/matplotlib/pull/26582
+matplotlib~=3.8 ; python_version == '3.12'
 more-itertools~=10.1
 networkx~=3.1
-numpy~=1.25 ; python_version == '3.11'
-numpy==1.26.0rc1 ; python_version == '3.12'
-pandas~=2.0 ; python_version == '3.11'
-pendulum~=2.1 ; python_version == '3.11'  # https://github.com/sdispater/pendulum/issues/696
+numpy~=1.26 ; python_version == '3.12'
+pandas~=2.1 ; python_version == '3.12'
+# pendulum~=2.1 # Doesn't support 3.12, see https://github.com/sdispater/pendulum/issues/696
 python-dateutil~=2.8
 pyyaml~=6.0
-scipy~=1.11
+scipy~=1.11 ; python_version == '3.12'
 sympy~=1.12
 toml~=0.10
 typing-extensions~=4.7
 tzdata~=2023.3
-yarl~=1.9 ; python_version == '3.11'  # https://github.com/aio-libs/yarl/issues/894
+#yarl~=1.9 # Doesn't support 3.12, see https://github.com/aio-libs/yarl/issues/894


### PR DESCRIPTION
This PR does a few things:
- Removes 3.10 & 3.11 in favour of 3.12 and 3.13-dev
- Use Python 3.12 as the default eval version
- Update eval-deps to support the two new versions of Python
- Bump all eval-deps to latest
- Removes the `toml` dep from eval-deps as it is now part of the stdlib