### PR TITLE
Multiple binary support api

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,4 +18,4 @@ ignore =
     # Type Annotations
     ANN002,ANN003,ANN101,ANN102,ANN204,ANN206
 
-per-file-ignores = tests/*:D1,ANN
+per-file-ignores = tests/*:D1,ANN,E202,E231,E241,E272,E702

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,11 +64,11 @@ Other things to look out for are breaking changes to NsJail's config format, its
 
 ## Adding and Updating Python Interpreters
 
-Python interpreters are built using pyenv via the `scripts/build_python.sh` helper script. This script accepts a pyenv version specifier (`pyenv install --list`) and builds the interpreter in a version-specific directory under `/lang/python`. In the image, each minor version of a Python interpreter should have its own build stage and the resulting `/lang/python` directory can be copied from that stage into the `base` stage.
+Python interpreters are built using pyenv via the `scripts/build_python.sh` helper script. This script accepts a pyenv version specifier (`pyenv install --list`) and builds the interpreter in a version-specific directory under `/snekbin/python`. In the image, each minor version of a Python interpreter should have its own build stage and the resulting `/snekbin/python` directory can be copied from that stage into the `base` stage.
 
 When updating a patch version (e.g. 3.11.3 to 3.11.4), edit the existing build stage in the image for the minor version (3.11); do not add a new build stage. To have access to a new version, pyenv likely needs to be updated. To do so, change the tag in the `git clone` command in the image, but only for the build stage that needs access to the new version. Updating pyenv for all build stages will just cause unnecessary build cache invalidations.
 
-To change the default interpreter used by NsJail, update the target of the `/lang/python/default` symlink created in the `base` stage.
+To change the default interpreter used by NsJail, update the target of the `/snekbin/python/default` symlink created in the `base` stage.
 
 [readme]: ../README.md
 [Dockerfile]: ../Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,11 @@ RUN apt-get -y update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --link --from=builder-nsjail /nsjail/nsjail /usr/sbin/
-COPY --link --from=builder-py-3_12 /lang/ /lang/
-COPY --link --from=builder-py-3_13 /lang/ /lang/
+COPY --link --from=builder-py-3_12 /snekbin/ /snekbin/
+COPY --link --from=builder-py-3_13 /snekbin/ /snekbin/
 
 RUN chmod +x /usr/sbin/nsjail \
-    && ln -s /lang/python/3.12/ /lang/python/default
+    && ln -s /snekbin/python/3.12/ /snekbin/python/default
 
 # ------------------------------------------------------------------------------
 FROM base as venv
@@ -79,7 +79,7 @@ RUN if [ -n "${DEV}" ]; \
     then \
         pip install -U -r requirements/coverage.pip \
         && export PYTHONUSERBASE=/snekbox/user_base \
-        && /lang/python/default/bin/python -m pip install --user numpy~=1.19; \
+        && /snekbin/python/default/bin/python -m pip install --user numpy~=1.19; \
     fi
 
 # At the end to avoid re-installing dependencies when only a config changes.

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ The above command will make the API accessible on the host via `http://localhost
 
 ### Python multi-version support
 
-By default, the binary that runs within nsjail is the binary specified by `DEFAULT_BINARY_PATH` at the top of [`nsjail.py`]. This can be overridden by specifying `binary_path` in the request body of calls to `POST /eval` or by setting the `binary_path` kwarg if calling `NSJail.python3()` directly.
+By default, the executable that runs within nsjail is defined by `DEFAULT_EXECUTABLE_PATH` at the top of [`nsjail.py`]. This can be overridden by specifying `executable_path` in the request body of calls to `POST /eval` or by setting the `executable_path` kwarg if calling `NSJail.python3()` directly.
 
-Any binary that exists within the container is a valid value for `binary_path`. The main use case of this feature is currently to specify the version of Python to use.
+Any executable that exists within the container is a valid value for `executable_path`. The main use case of this feature is currently to specify the version of Python to use.
 
 Python versions currently available can be found in the [`Dockerfile`] by looking for build stages that match `builder-py-*`. These binaries are then copied into the `base` build stage further down.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ To run it in the background, use the `-d` option. See the documentation on [`doc
 
 The above command will make the API accessible on the host via `http://localhost:8060/`. Currently, there's only one endpoint: `http://localhost:8060/eval`.
 
+### Python multi-version support
+
+By default, the binary ran within nsjail is the binary specified by `DEFAULT_BINARY_PATH` at the top of [`nsjail.py`]. This can be overridden by specifying `binary_path` in the request body of calls to `POST /eval` or by setting the `binary_path` kwarg if calling `NSJail.python3()` directly.
+
+Any binary that exists within the container is a valid value for `binary_path`. The main use case of this feature is currently to specify the version of Python to use.
+
+Python versions currently available can be found in the [`Dockerfile`] by looking for build stages that match `builder-py-*`. These binaries are then copied into the `base` build stage further down.
+
 ## Configuration
 
 Configuration files can be edited directly. However, this requires rebuilding the image. Alternatively, a Docker volume or bind mounts can be used to override the configuration files at their default locations.
@@ -126,9 +134,11 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 [7]: https://github.com/google/nsjail/blob/master/config.proto
 [`gunicorn.conf.py`]: config/gunicorn.conf.py
 [`snekbox.cfg`]: config/snekbox.cfg
+[`nsjail.py`]: snekbox/nsjail.py
 [`snekapi.py`]: snekbox/api/snekapi.py
 [`resources`]: snekbox/api/resources
 [`docker-compose.yml`]: docker-compose.yml
+[`Dockerfile`]: Dockerfile
 [`docker run`]: https://docs.docker.com/engine/reference/commandline/run/
 [nsjail]: https://github.com/google/nsjail
 [falcon]: https://falconframework.org/

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To expose third-party Python packages during evaluation, install them to a custo
 
 ```sh
 docker exec snekbox /bin/sh -c \
-    'PYTHONUSERBASE=/snekbox/user_base /lang/python/default/bin/python -m pip install --user numpy'
+    'PYTHONUSERBASE=/snekbox/user_base /snekbin/python/default/bin/python -m pip install --user numpy'
 ```
 
 In the above command, `snekbox` is the name of the running container. The name may be different and can be checked with `docker ps`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The above command will make the API accessible on the host via `http://localhost
 
 ### Python multi-version support
 
-By default, the binary ran within nsjail is the binary specified by `DEFAULT_BINARY_PATH` at the top of [`nsjail.py`]. This can be overridden by specifying `binary_path` in the request body of calls to `POST /eval` or by setting the `binary_path` kwarg if calling `NSJail.python3()` directly.
+By default, the binary that runs within nsjail is the binary specified by `DEFAULT_BINARY_PATH` at the top of [`nsjail.py`]. This can be overridden by specifying `binary_path` in the request body of calls to `POST /eval` or by setting the `binary_path` kwarg if calling `NSJail.python3()` directly.
 
 Any binary that exists within the container is a valid value for `binary_path`. The main use case of this feature is currently to specify the version of Python to use.
 

--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -103,8 +103,3 @@ cgroup_pids_max: 6
 cgroup_pids_mount: "/sys/fs/cgroup/pids"
 
 iface_no_lo: true
-
-exec_bin {
-    path: "/lang/python/default/bin/python"
-    arg: ""
-}

--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -81,8 +81,8 @@ mount {
 }
 
 mount {
-    src: "/lang"
-    dst: "/lang"
+    src: "/snekbin"
+    dst: "/snekbin"
     is_bind: true
     rw: false
 }

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -4,14 +4,14 @@ shopt -s inherit_errexit
 
 py_version="${1}"
 
-# Install Python interpreter under e.g. /lang/python/3.11/ (no patch version).
+# Install Python interpreter under e.g. /snekbin/python/3.11/ (no patch version).
 "${PYENV_ROOT}/plugins/python-build/bin/python-build" \
     "${py_version}" \
-    "/lang/python/${py_version%[-.]*}"
-"/lang/python/${py_version%[-.]*}/bin/python" -m pip install -U pip
+    "/snekbin/python/${py_version%[-.]*}"
+"/snekbin/python/${py_version%[-.]*}/bin/python" -m pip install -U pip
 
 # Clean up some unnecessary files to reduce image size bloat.
-find /lang/python/ -depth \
+find /snekbin/python/ -depth \
 \( \
     \( -type d -a \( \
         -name test -o -name tests -o -name idle_test \

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -7,8 +7,8 @@ py_version="${1}"
 # Install Python interpreter under e.g. /lang/python/3.11/ (no patch version).
 "${PYENV_ROOT}/plugins/python-build/bin/python-build" \
     "${py_version}" \
-    "/lang/python/${py_version%.*}"
-"/lang/python/${py_version%.*}/bin/python" -m pip install -U pip
+    "/lang/python/${py_version%[-.]*}"
+"/lang/python/${py_version%[-.]*}/bin/python" -m pip install -U pip
 
 # Clean up some unnecessary files to reduce image size bloat.
 find /lang/python/ -depth \

--- a/scripts/install_eval_deps.sh
+++ b/scripts/install_eval_deps.sh
@@ -1,5 +1,5 @@
 set -euo pipefail
 
 export PYTHONUSERBASE=/snekbox/user_base
-find /lang/python -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0I{} bash -c \
+find /snekbin/python -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0I{} bash -c \
     '{}/bin/python -m pip install --user -U -r requirements/eval-deps.pip' \;

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -128,11 +128,8 @@ class EvalResource:
         binary_path = body.get("binary_path")
         if binary_path:
             binary_path = Path(binary_path)
-            if (
-                not binary_path.resolve().as_posix().startswith("/lang/")
-                or not binary_path.is_file()
-            ):
-                raise falcon.HTTPBadRequest(title="binary_path file is invalid")
+            if not binary_path.is_file():
+                raise falcon.HTTPBadRequest(title="binary_path is not a file")
 
         try:
             result = self.nsjail.python3(

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -128,6 +128,8 @@ class EvalResource:
         binary_path = body.get("binary_path")
         if binary_path:
             binary_path = Path(binary_path)
+            if not binary_path.exists():
+                raise falcon.HTTPBadRequest(title="binary_path does not exist")
             if not binary_path.is_file():
                 raise falcon.HTTPBadRequest(title="binary_path is not a file")
 

--- a/snekbox/api/resources/eval.py
+++ b/snekbox/api/resources/eval.py
@@ -132,6 +132,8 @@ class EvalResource:
                 raise falcon.HTTPBadRequest(title="binary_path does not exist")
             if not binary_path.is_file():
                 raise falcon.HTTPBadRequest(title="binary_path is not a file")
+            if not binary_path.stat().st_mode & 0o100 == 0o100:
+                raise falcon.HTTPBadRequest(title="binary_path is not executable")
 
         try:
             result = self.nsjail.python3(

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 LOG_PATTERN = re.compile(
     r"\[(?P<level>(I)|[DWEF])\]\[.+?\](?(2)|(?P<func>\[\d+\] .+?:\d+ )) ?(?P<msg>.+)"
 )
-DEFAULT_BINARY_PATH = "/snekbin/python/default/bin/python"
+DEFAULT_EXECUTABLE_PATH = "/snekbin/python/default/bin/python"
 
 
 class NsJail:
@@ -174,7 +174,7 @@ class NsJail:
         nsjail_args: Iterable[str],
         log_path: str,
         fs_home: str,
-        binary_path: str,
+        executable_path: str,
     ) -> Sequence[str]:
         if self.cgroup_version == 2:
             nsjail_args = ("--use_cgroupv2", *nsjail_args)
@@ -203,7 +203,7 @@ class NsJail:
             log_path,
             *nsjail_args,
             "--",
-            binary_path,
+            executable_path,
             *iter_lstrip(py_args),
         ]
 
@@ -262,7 +262,7 @@ class NsJail:
         py_args: Iterable[str],
         files: Iterable[FileAttachment] = (),
         nsjail_args: Iterable[str] = (),
-        binary_path: Path = DEFAULT_BINARY_PATH,
+        executable_path: Path = DEFAULT_EXECUTABLE_PATH,
     ) -> EvalResult:
         """
         Execute Python 3 code in an isolated environment and return the completed process.
@@ -271,14 +271,20 @@ class NsJail:
             py_args: Arguments to pass to Python.
             files: FileAttachments to write to the sandbox prior to running Python.
             nsjail_args: Overrides for the NsJail configuration.
-            binary_path: The path to the binary to execute under.
+            executable_path: The path to the executable to run within nsjail.
         """
         with NamedTemporaryFile() as nsj_log, MemFS(
             instance_size=self.memfs_instance_size,
             home=self.memfs_home,
             output=self.memfs_output,
         ) as fs:
-            args = self._build_args(py_args, nsjail_args, nsj_log.name, str(fs.home), binary_path)
+            args = self._build_args(
+                py_args,
+                nsjail_args,
+                nsj_log.name,
+                str(fs.home),
+                executable_path,
+            )
             try:
                 files_written = self._write_files(fs.home, files)
 

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 LOG_PATTERN = re.compile(
     r"\[(?P<level>(I)|[DWEF])\]\[.+?\](?(2)|(?P<func>\[\d+\] .+?:\d+ )) ?(?P<msg>.+)"
 )
+DEFAULT_BINARY_PATH = "/snekbin/python/default/bin/python"
 
 
 class NsJail:
@@ -168,7 +169,12 @@ class NsJail:
         return "".join(output)
 
     def _build_args(
-        self, py_args: Iterable[str], nsjail_args: Iterable[str], log_path: str, fs_home: str, binary_path: str
+        self,
+        py_args: Iterable[str],
+        nsjail_args: Iterable[str],
+        log_path: str,
+        fs_home: str,
+        binary_path: str,
     ) -> Sequence[str]:
         if self.cgroup_version == 2:
             nsjail_args = ("--use_cgroupv2", *nsjail_args)
@@ -185,7 +191,7 @@ class NsJail:
         nsjail_args = (
             # Mount `home` with Read/Write access
             "--bindmount",
-            f"{fs_home}:home",
+            f"{fs_home}:home",  # noqa: E231
             *nsjail_args,
         )
 
@@ -256,7 +262,7 @@ class NsJail:
         py_args: Iterable[str],
         files: Iterable[FileAttachment] = (),
         nsjail_args: Iterable[str] = (),
-        binary_path: Path = "/lang/python/default/bin/python",
+        binary_path: Path = DEFAULT_BINARY_PATH,
     ) -> EvalResult:
         """
         Execute Python 3 code in an isolated environment and return the completed process.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,12 +65,12 @@ class IntegrationTests(unittest.TestCase):
                     "test default binary is used when binary_path not specified",
                 ),
                 (
-                    get_python_version_body | {"binary_path": "/lang/python/3.12/bin/python"},
+                    get_python_version_body | {"binary_path": "/snekbin/python/3.12/bin/python"},
                     "3.12\n",
                     "test default binary is used when explicitly set",
                 ),
                 (
-                    get_python_version_body | {"binary_path": "/lang/python/3.13/bin/python"},
+                    get_python_version_body | {"binary_path": "/snekbin/python/3.13/bin/python"},
                     "3.13\n",
                     "test alternative binary is used when set",
                 ),
@@ -85,10 +85,10 @@ class IntegrationTests(unittest.TestCase):
         """Test that passing invalid binary paths result in no code execution."""
         with run_gunicorn():
             cases = [
-                ("/bin/bash", "test files outside of /lang cannot be run"),
+                ("/bin/bash", "test files outside of /snekbin cannot be run"),
                 (
-                    "/lang/../bin/bash",
-                    "test path traversal still stops files outside /lang from running",
+                    "/snekbin/../bin/bash",
+                    "test path traversal still stops files outside /snekbin from running",
                 ),
                 ("/foo/bar", "test non-existant files are not run"),
             ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,19 +85,19 @@ class IntegrationTests(unittest.TestCase):
         """Test that passing invalid binary paths result in no code execution."""
         with run_gunicorn():
             cases = [
-                ("/bin/bash", "test files outside of /snekbin cannot be run"),
+                ("/abc/def", "test non-existant files are not run", "binary_path does not exist"),
+                ("/snekbin", "test directories are not ran", "binary_path is not a file"),
                 (
-                    "/snekbin/../bin/bash",
-                    "test path traversal still stops files outside /snekbin from running",
+                    "/etc/hostname",
+                    "test non-executable files are not ran",
+                    "binary_path is not executable",
                 ),
-                ("/foo/bar", "test non-existant files are not run"),
             ]
-            for path, msg in cases:
-                with self.subTest(msg=msg, path=path):
+            for path, msg, expected in cases:
+                with self.subTest(msg=msg, path=path, expected=expected):
                     body = {"args": ["-c", "echo", "hi"], "binary_path": path}
                     response, status = snekbox_request(body)
                     self.assertEqual(status, 400)
-                    expected = {"title": "binary_path file is invalid"}
                     self.assertEqual(json.loads(response)["stdout"], expected)
 
     def test_eval(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,11 +85,11 @@ class IntegrationTests(unittest.TestCase):
         """Test that passing invalid binary paths result in no code execution."""
         with run_gunicorn():
             cases = [
-                ("/abc/def", "test non-existant files are not run", "binary_path does not exist"),
-                ("/snekbin", "test directories are not ran", "binary_path is not a file"),
+                ("/abc/def", "test non-existent files are not run", "binary_path does not exist"),
+                ("/snekbin", "test directories are not run", "binary_path is not a file"),
                 (
                     "/etc/hostname",
-                    "test non-executable files are not ran",
+                    "test non-executable files are not run",
                     "binary_path is not executable",
                 ),
             ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,12 +85,12 @@ class IntegrationTests(unittest.TestCase):
         """Test that passing invalid binary paths result in no code execution."""
         with run_gunicorn():
             cases = [
-                ("/bin/bash", "test files outside of /lang cannot be ran"),
+                ("/bin/bash", "test files outside of /lang cannot be run"),
                 (
                     "/lang/../bin/bash",
                     "test path traversal still stops files outside /lang from running",
                 ),
-                ("/foo/bar", "test non-existant files are not ran"),
+                ("/foo/bar", "test non-existant files are not run"),
             ]
             for path, msg in cases:
                 with self.subTest(msg=msg, path=path):

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -26,6 +26,8 @@ class NsJailTests(unittest.TestCase):
         # Hard-coded because it's non-trivial to parse the mount options.
         self.shm_mount_size = 40 * Size.MiB
 
+        self.default_binary_path = "/lang/python/default/bin/python"
+
     def eval_code(self, code: str):
         return self.nsjail.python3(["-c", code])
 
@@ -547,7 +549,7 @@ class NsJailTests(unittest.TestCase):
         for args, expected in cases:
             with self.subTest(args=args):
                 result = self.nsjail.python3(py_args=args)
-                idx = result.args.index(self.nsjail.config.exec_bin.path)
+                idx = result.args.index(self.default_binary_path)
                 self.assertEqual(result.args[idx + 1 :], expected)
                 self.assertEqual(result.returncode, 0)
 

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -9,7 +9,7 @@ from itertools import product
 from pathlib import Path
 from textwrap import dedent
 
-from snekbox.nsjail import NsJail
+from snekbox.nsjail import DEFAULT_EXECUTABLE_PATH, NsJail
 from snekbox.snekio import FileAttachment
 from snekbox.snekio.filesystem import Size
 
@@ -25,8 +25,6 @@ class NsJailTests(unittest.TestCase):
 
         # Hard-coded because it's non-trivial to parse the mount options.
         self.shm_mount_size = 40 * Size.MiB
-
-        self.default_binary_path = "/snekbin/python/default/bin/python"
 
     def eval_code(self, code: str):
         return self.nsjail.python3(["-c", code])
@@ -549,7 +547,7 @@ class NsJailTests(unittest.TestCase):
         for args, expected in cases:
             with self.subTest(args=args):
                 result = self.nsjail.python3(py_args=args)
-                idx = result.args.index(self.default_binary_path)
+                idx = result.args.index(DEFAULT_EXECUTABLE_PATH)
                 self.assertEqual(result.args[idx + 1 :], expected)
                 self.assertEqual(result.returncode, 0)
 

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -26,7 +26,7 @@ class NsJailTests(unittest.TestCase):
         # Hard-coded because it's non-trivial to parse the mount options.
         self.shm_mount_size = 40 * Size.MiB
 
-        self.default_binary_path = "/lang/python/default/bin/python"
+        self.default_binary_path = "/snekbin/python/default/bin/python"
 
     def eval_code(self, code: str):
         return self.nsjail.python3(["-c", code])
@@ -84,7 +84,7 @@ class NsJailTests(unittest.TestCase):
             for _ in range({max_pids}):
                 print(subprocess.Popen(
                     [
-                        '/lang/python/default/bin/python',
+                        '/snekbin/python/default/bin/python',
                         '-c',
                         'import time; time.sleep(1)'
                     ],


### PR DESCRIPTION
This allows setting a `binary_path` key in the request body to `/eval` to specify which binary to run under.

If not supplied, it defaults to `"/snekbin/python/default/bin/python"`.

https://github.com/python-discord/snekbox/pull/196/commits/0c9b234011f21ce7bdc993957867610dfec1258f is needed as previously we were dropping the text after the last period when creating the path to install Python to. However, for versions such as3.13-dev this would result in it being installed into `/snekbin/3`. Instead, we now split on the last `.` _or_ the last `-`
