### PR TITLE
Bump max memory to 70MiB

### DIFF
--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -95,7 +95,7 @@ mount {
     options: "size=40m"
 }
 
-cgroup_mem_max: 52428800
+cgroup_mem_max: 73400320
 cgroup_mem_swap_max: 0
 cgroup_mem_mount: "/sys/fs/cgroup/memory"
 


### PR DESCRIPTION
pandas now uses ~60MiB just to import, so the previous max was no longer enough.

We have enough memory to spare in the production cluster for this bump