### PR TITLE
Bump snekbox up to Python 3.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ COPY --link scripts/build_python.sh /
 
 # ------------------------------------------------------------------------------
 FROM builder-py-base as builder-py-3_12
-RUN git clone -b v2.3.28 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && /build_python.sh 3.12.0
+RUN git clone -b v2.3.36 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && /build_python.sh 3.12.2
 # ------------------------------------------------------------------------------
 FROM python:3.11-slim-bookworm as base
 

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -1,4 +1,4 @@
-anyio[trio]~=4.2
+anyio[trio]~=4.3
 arrow~=1.3
 attrs~=23.2
 beautifulsoup4~=4.12
@@ -8,16 +8,16 @@ forbiddenfruit~=0.1
 fuzzywuzzy~=0.18
 lark~=1.1
 matplotlib~=3.8 ; python_version == '3.12'
-more-itertools~=10.1
+more-itertools~=10.2
 networkx~=3.2
 numpy~=1.26 ; python_version == '3.12'
-pandas~=2.1 ; python_version == '3.12'
+pandas~=2.2 ; python_version == '3.12'
 pendulum~=3.0
 pyarrow~=15.0
-python-dateutil~=2.8
+python-dateutil~=2.9
 pyyaml~=6.0
-scipy~=1.11 ; python_version == '3.12'
+scipy~=1.12 ; python_version == '3.12'
 sympy~=1.12
-typing-extensions~=4.9
-tzdata~=2023.4
+typing-extensions~=4.10
+tzdata~=2024.1
 # yarl~=1.9  Requires multidict wheels in order to build https://github.com/aio-libs/multidict/issues/887

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -20,4 +20,4 @@ scipy~=1.12 ; python_version == '3.12'
 sympy~=1.12
 typing-extensions~=4.10
 tzdata~=2024.1
-# yarl~=1.9  Requires multidict wheels in order to build https://github.com/aio-libs/multidict/issues/887
+yarl~=1.9


### PR DESCRIPTION
pyenv 2.3.36 added support for 3.12.2, it also happens to be the latest version as of writing.

I also bumped eval-deps up and reenabled yarl as multidict has 3.12 wheels now.