### PR TITLE
Use xargs over find -exec to ensure exit code is returned properly

### DIFF
--- a/scripts/install_eval_deps.sh
+++ b/scripts/install_eval_deps.sh
@@ -1,5 +1,5 @@
 set -euo pipefail
 
 export PYTHONUSERBASE=/snekbox/user_base
-find /lang/python -mindepth 1 -maxdepth 1 -type d -exec \
-    {}/bin/python -m pip install --user -U -r requirements/eval-deps.pip \;
+find /lang/python -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0I{} bash -c \
+    '{}/bin/python -m pip install --user -U -r requirements/eval-deps.pip' \;


### PR DESCRIPTION
Running this script in it's previous form (via `docker compose run`) always returned an exit code of 0. This is due to `find` always returning a 0 exit code, unless an error occurred while traversing the directories.

This caused CI to always report a success when isntalling deps, even when pip failed.