### PR TITLE
raise error if attachment pathname contains invalid bytes

### DIFF
--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -14,6 +14,7 @@ from snekbox.config_pb2 import NsJailConfig
 from snekbox.limits.timed import time_limit
 from snekbox.result import EvalError, EvalResult
 from snekbox.snekio import FileAttachment, MemFS
+from snekbox.snekio.errors import IllegalPathError
 from snekbox.snekio.filesystem import Size
 from snekbox.utils.iter import iter_lstrip
 
@@ -244,6 +245,9 @@ class NsJail:
         except TimeoutError as e:
             log.info(f"Exceeded time limit while parsing attachments: {e}")
             raise EvalError("TimeoutError: Exceeded time limit while parsing attachments") from e
+        except IllegalPathError as e:
+            log.info(f"Invalid bytes in filename while parsing attachments: {e}")
+            raise EvalError("FileParsingError: invalid bytes in filename while parsing attachments")
         except Exception as e:
             log.exception(f"Unexpected {type(e).__name__} while parse attachments", exc_info=e)
             raise EvalError("FileParsingError: Unknown error while parsing attachments") from e

--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -247,7 +247,9 @@ class NsJail:
             raise EvalError("TimeoutError: Exceeded time limit while parsing attachments") from e
         except IllegalPathError as e:
             log.info(f"Invalid bytes in filename while parsing attachments: {e}")
-            raise EvalError("FileParsingError: invalid bytes in filename while parsing attachments")
+            raise EvalError(
+                "FileParsingError: invalid bytes in filename while parsing attachments"
+            ) from e
         except Exception as e:
             log.exception(f"Unexpected {type(e).__name__} while parse attachments", exc_info=e)
             raise EvalError("FileParsingError: Unknown error while parsing attachments") from e

--- a/snekbox/snekio/attachment.py
+++ b/snekbox/snekio/attachment.py
@@ -67,8 +67,17 @@ class FileAttachment:
         Args:
             file: The file to attach.
             relative_to: The root for the path name.
+        Raises:
+            IllegalPathError: If path name contains characters that can't be encoded in UTF-8
         """
         path = file.relative_to(relative_to) if relative_to else file
+
+        # Disallow filenames with chars that can't be encoded in UTF-8
+        try:
+            str(path).encode("utf-8")
+        except UnicodeEncodeError as e:
+            raise IllegalPathError("File paths may not contain invalid byte sequences") from e
+
         return cls(str(path), file.read_bytes())
 
     @property

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -252,12 +252,12 @@ class NsJailTests(unittest.TestCase):
 
     def test_filename_encoding_illegal_chars(self):
         code = dedent(
-            """
+            r"""
             with open(b"\xC3.txt", "w") as f:
                 f.write("test")
             """
         ).strip()
-        result = self.eval_code(code)
+        result = self.eval_file(code)
         self.assertEqual(result.returncode, None)
         self.assertEqual(
             result.stdout, "FileParsingError: invalid bytes in filename while parsing attachments"

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -250,6 +250,20 @@ class NsJailTests(unittest.TestCase):
         )
         self.assertEqual(result.stderr, None)
 
+    def test_filename_encoding_illegal_chars(self):
+        code = dedent(
+            """
+            with open(b"\xC3.txt", "w") as f:
+                f.write("test")
+            """
+        ).strip()
+        result = self.eval_code(code)
+        self.assertEqual(result.returncode, None)
+        self.assertEqual(
+            result.stdout, "FileParsingError: invalid bytes in filename while parsing attachments"
+        )
+        self.assertEqual(result.stderr, None)
+
     def test_file_parsing_depth_limit(self):
         code = dedent(
             """


### PR DESCRIPTION
safe_path is used for input, to parse a file path from the dict. This error is occurring when doing the reverse. This change throws an EvalError if any file created by the Python code isn't able to be encoded in UTF-8. 