### PR TITLE
Migration to official Sentry release CI action

### DIFF
--- a/.github/workflows/sentry_release.yaml
+++ b/.github/workflows/sentry_release.yaml
@@ -24,12 +24,12 @@ jobs:
           printf "%s\n" "${version}"
 
       - name: Create a Sentry.io release
-        uses: tclindner/sentry-releases-action@v1.3.0
+        uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: snekbox
         with:
-          tagName: ${{ steps.version.outputs.version }}
+          version: ${{ steps.version.outputs.version }}
           environment: production
-          releaseNamePrefix: snekbox@
+          version_prefix: snekbox@


### PR DESCRIPTION
https://github.com/tclindner/sentry-releases-action no longer works, this PR migrates to the [official sentry release CI action](https://github.com/getsentry/action-release).