### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ COPY --link scripts/build_python.sh /
 
 # ------------------------------------------------------------------------------
 FROM builder-py-base as builder-py-3_12
-RUN git clone -b v2.3.36 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
-    && /build_python.sh 3.12.2
+RUN git clone -b v2.4.10 --depth 1 https://github.com/pyenv/pyenv.git $PYENV_ROOT \
+    && /build_python.sh 3.12.5
 # ------------------------------------------------------------------------------
 FROM python:3.12-slim-bookworm as base
 

--- a/requirements/eval-deps.pip
+++ b/requirements/eval-deps.pip
@@ -1,23 +1,23 @@
-anyio[trio]~=4.3
+anyio[trio]~=4.4
 arrow~=1.3
-attrs~=23.2
+attrs~=24.2
 beautifulsoup4~=4.12
 einspect~=0.5 ; python_version == '3.12'
-fishhook~=0.3.1
+fishhook~=0.3
 forbiddenfruit~=0.1
 fuzzywuzzy~=0.18
-lark~=1.1
-matplotlib~=3.8 ; python_version == '3.12'
-more-itertools~=10.2
-networkx~=3.2
-numpy~=1.26 ; python_version == '3.12'
+lark~=1.2
+matplotlib~=3.9 ; python_version == '3.12'
+more-itertools~=10.4
+networkx~=3.3
+numpy~=2.1 ; python_version == '3.12'
 pandas~=2.2 ; python_version == '3.12'
 pendulum~=3.0
-pyarrow~=15.0
+pyarrow~=17.0
 python-dateutil~=2.9
 pyyaml~=6.0
-scipy~=1.12 ; python_version == '3.12'
-sympy~=1.12
-typing-extensions~=4.10
+scipy~=1.14 ; python_version == '3.12'
+sympy~=1.13
+typing-extensions~=4.12
 tzdata~=2024.1
 yarl~=1.9


### PR DESCRIPTION
This bumps Pytohn version within each container to 3.12.5 and bumps eval-deps to latest.