### PR TITLE
Enable 3.13's colorized output (snekbox half)

### DIFF
--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -18,6 +18,7 @@ envar: "PYTHONDONTWRITEBYTECODE=true"
 envar: "PYTHONIOENCODING=utf-8:strict"
 envar: "PYTHONUNBUFFERED=true"
 envar: "PYTHONUSERBASE=/snekbox/user_base"
+envar: "PYTHON_COLORS=1"
 envar: "HOME=/home"
 
 keep_caps: false


### PR DESCRIPTION
This PR is the snekbox side of changes made to allow bot's `!eval` to support colored output. The first of the two commits for bot's side allows ANSI codes to be rendered when given via `print` or such, but Python 3.13 does not produce these colors in tracebacks without an environment variable. [Per documentation](https://docs.python.org/3.13/using/cmdline.html#controlling-color), there are two such envars - `PYTHON_COLORS` and `FORCE_COLOR`. Testing has shown `FORCE_COLOR` to have no effect in eval output, while `PYTHON_COLORS` (even by itself) produces colored tracebacks.

The insertion of ANSI codes produces significant problems when code is long enough to require uploading to pinnwand, however, so this PR probably *should not be merged* unless the `Prevent 3.13's ANSI escapes from mangling pinnwand uploads` commit from bot's PR is also merged, which fixes the problems.

python-discord/bot#3198 is bot's half