### PR TITLE
Upgrade 3.14 binary to 3.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM buildpack-deps:bookworm AS builder-py-base
 
 ENV PYENV_ROOT=/pyenv \
     PYTHON_CONFIGURE_OPTS='--disable-test-modules --enable-optimizations \
-        --with-lto --with-system-expat --without-ensurepip'
+        --with-lto --without-ensurepip'
 
 RUN apt-get -y update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Originally introduced in commits c7fae913df7c186ea12467b10afb56b2d00c71a7 and
b7e0aeca1ebeab72fd47c7cc41b54a45542406e9.

These commits failed in CI as the tests that are run when pyenv has built a Python
binary failed:

``` sh
 > [builder-py-3_14 1/1] RUN /build_python.sh 3.14.0:
996.0 
996.0 FAILED (failures=3, skipped=10)
996.0 test test_xml_etree_c failed
996.0 0:02:06 load avg: 3.06 [43/43] test_xml_etree_c failed (3 failures)
996.0 
996.0 Total duration: 2 min 6 sec
996.0 Total tests: run=9,295 failures=6 skipped=314
996.0 Total test files: run=43/43 failed=2 skipped=1
996.0 Result: FAILURE
996.0 make: *** [Makefile:1019: profile-run-stamp] Error 2
------
ERROR: failed to build: failed to solve: process "/bin/sh -c /build_python.sh 3.14.0" did not complete successfully: exit code: 1
```

I'm not sure entirely what about the way we build here caused that, and don't
think this is explicitly caused by any flags that we are setting (or amending
from defaults).