### PR TITLE
Mount system Python binaries and libraries for generic image

### DIFF
--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -89,6 +89,20 @@ mount {
 }
 
 mount {
+    src: "/usr/local/bin/python"
+    dst: "/usr/local/bin/python"
+    is_bind: true
+    rw: false
+}
+
+mount {
+    src: "/usr/local/lib"
+    dst: "/usr/local/lib"
+    is_bind: true
+    rw: false
+}
+
+mount {
     dst: "/dev/shm"
     fstype: "tmpfs"
     rw: true


### PR DESCRIPTION
After #248 the new `:latest` image (as opposed to the `:latest-pydis`) image was in a broken state as the default Python symlinked to `/usr/local/bin` which was then not mounted in nsjail.

This PR fixes that by mounting the system Python interpreter to the container and mounting `/usr/local/lib` (which in sneakbox images still only contains Python libraries and system-level dependencies).

This will of course change the `:latest-pydis` image in that the system Python will now be available in the jail (whereas before it was only the specific versions we were adding), though I think this poses little problem for us as it's not going to be called by any of the calls from [`python-discord/bot`](https://github.com/python-discord/bot) and doesn't give any additional powers or capabilities. We could toggle this mounting off with a feature flag/config option somewhere but I think the gain is so minimal it's not worth it.

The custom user base still stores additional dependencies that users may wish to add and is still looked at by the system Python when an evaluation is triggered.

Closes #255 