### PR TITLE
Add arm64 support to deploy workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           # The version script relies on history. Fetch 100 commits to be safe.
           fetch-depth: 100
@@ -42,12 +42,12 @@ jobs:
       # which comes with BuildKit. It has cache features which can speed up
       # the builds. See https://github.com/docker/build-push-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: network=host
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -81,7 +81,7 @@ jobs:
       # If configured by the cache_config step, also cache the layers in
       # GitHub Actions.
       - name: Build image for linting and testing
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -96,7 +96,7 @@ jobs:
           tags: localhost:5000/local/snekbox-venv:${{ steps.version.outputs.version }}
 
       - name: Build integration image for testing
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.pydis
@@ -113,7 +113,7 @@ jobs:
       # Make the image available as an artifact so other jobs will be able to
       # download it.
       - name: Upload image archive as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.artifact }}
           path: ${{ env.artifact }}.tar

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Download image artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact }}
 
@@ -32,19 +32,19 @@ jobs:
         run: docker load -i ${{ inputs.artifact }}.tar
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: network=host
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           # The version script relies on history. Fetch 100 commits to be safe.
           fetch-depth: 100
@@ -52,7 +52,7 @@ jobs:
       # Build the final production image and push it to GHCR.
       # Tag it with both the short commit SHA and 'latest'.
       - name: Build final image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -68,7 +68,7 @@ jobs:
             localhost:5000/local/snekbox:${{ inputs.version }}
 
       - name: Build PyDis final image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.pydis
@@ -83,16 +83,16 @@ jobs:
 
       # Deploy to Kubernetes.
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
 
       - name: Authenticate with Kubernetes
-        uses: azure/k8s-set-context@v4
+        uses: azure/k8s-set-context@v5
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.KUBECONFIG }}
 
       - name: Deploy to Kubernetes
-        uses: azure/k8s-deploy@v5
+        uses: azure/k8s-deploy@v6
         with:
           namespace: snekbox
           manifests: deployment.yaml
@@ -100,7 +100,7 @@ jobs:
 
       # Push the base image to GHCR, with an inline cache manifest.
       - name: Push base image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -114,7 +114,7 @@ jobs:
 
       # Push the venv image to GHCR, with an inline cache manifest.
       - name: Push venv image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,6 +31,9 @@ jobs:
       - name: Load image from archive
         run: docker load -i ${{ inputs.artifact }}.tar
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
@@ -57,6 +60,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: |
             ghcr.io/python-discord/snekbox-base:latest
             ghcr.io/python-discord/snekbox-venv:latest
@@ -73,6 +77,7 @@ jobs:
           context: .
           file: ./Dockerfile.pydis
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: |
             ghcr.io/python-discord/snekbox:latest-pydis
           build-args: SNEKBOX_IMAGE=localhost:5000/local/snekbox:${{ inputs.version }}
@@ -106,6 +111,7 @@ jobs:
           file: ./Dockerfile
           target: base
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: ghcr.io/python-discord/snekbox-base:latest
           cache-to: type=inline
           tags: |
@@ -120,6 +126,7 @@ jobs:
           file: ./Dockerfile
           target: venv
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: |
             ghcr.io/python-discord/snekbox-base:latest
             ghcr.io/python-discord/snekbox-venv:latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
         id: python
@@ -25,7 +25,7 @@ jobs:
         run: pip install -U -r requirements/lint.pip
 
       - name: Pre-commit environment cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
           key: "precommit-0-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\

--- a/.github/workflows/sentry_release.yaml
+++ b/.github/workflows/sentry_release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           # The version script relies on history. Fetch 100 commits to be safe.
           fetch-depth: 100

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download image artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact }}
 
@@ -23,7 +23,7 @@ jobs:
 
       # Needed for the Docker Compose file.
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Memory limit tests would fail if this isn't disabled.
       - name: Disable swap memory
@@ -43,7 +43,7 @@ jobs:
 
       # Upload it so the coverage from all matrix jobs can be combined later.
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: .coverage
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -70,7 +70,7 @@ jobs:
         run: pip install -U -r requirements/coverage.pip
 
       - name: Download coverage data
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage
           merge-multiple: true
@@ -95,7 +95,7 @@ jobs:
     needs: test
     steps:
       - name: Download image artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact }}
 
@@ -104,7 +104,7 @@ jobs:
 
       # Needed for the Docker Compose file.
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Install eval deps the same way as init container from deployment.yaml
       # This is to ensure that deployment won't fail at that step


### PR DESCRIPTION
Adds QEMU and linux/arm64 platform to all production image builds in the deploy workflow. The test/lint build is left as amd64-only since those images are only consumed by the runner itself.