### PR TITLE
Make /lib64 mount optional

### DIFF
--- a/config/snekbox.cfg
+++ b/config/snekbox.cfg
@@ -65,6 +65,7 @@ mount {
     dst: "/lib64"
     is_bind: true
     rw: false
+    mandatory: false
 }
 
 mount {


### PR DESCRIPTION
Snekbox currently fails using on ARM systems (with the images introduced in #258) as the `/lib64` path we mount as part of the default config does not exist on ARM platforms.

All necessary system libraries should be present in /lib when on ARM and removing this mount entirely works fine on ARM architectures.

Adding the "mandatory: false" will still generate a warning on ARM systems (where the path does not exist) but will not fail the nsjail process, which I think is fine. If we want we could try remove the warning but given we run snekbox on AMD in production I don't think it's a major issue.